### PR TITLE
fix: clean BBQr implementation, move MAX button

### DIFF
--- a/components/BBQrDynamicQRCode.js
+++ b/components/BBQrDynamicQRCode.js
@@ -27,17 +27,18 @@ export class BBQrDynamicQRCode extends Component {
   fragments = [];
 
   componentDidMount() {
-    const { value } = this.props;
+    const { value, fileType = 'P' } = this.props;
     try {
-      // Use BBQr to split PSBT into multiple QR codes
-      const result = splitQRs(value, {
-        encoding: 'Z', // Use Zlib compression for best size
+      // Convert base64 PSBT string to Uint8Array for BBQr
+      const raw = Uint8Array.from(Buffer.from(value, 'base64'));
+      const result = splitQRs(raw, fileType, {
+        encoding: 'Z',
         minVersion: 5,
         maxVersion: 40,
       });
-      
+
       this.fragments = result.parts;
-      console.log('[BBQr] Split PSBT into', this.fragments.length, 'parts, encoding:', result.encoding);
+      console.log('[BBQr] Split into', this.fragments.length, 'parts, encoding:', result.encoding);
       
       this.setState(
         {

--- a/components/DynamicPSBTQRCode.js
+++ b/components/DynamicPSBTQRCode.js
@@ -57,12 +57,13 @@ export class DynamicPSBTQRCode extends Component {
     
     // Fall back to BBQr (for Jade, Passport, etc.)
     try {
-      const bbqrResult = splitBBQrQRs(value, {
+      const raw = Uint8Array.from(Buffer.from(value, 'base64'));
+      const bbqrResult = splitBBQrQRs(raw, 'P', {
         encoding: 'Z',
         minVersion: 5,
         maxVersion: 40,
       });
-      
+
       if (bbqrResult.parts && bbqrResult.parts.length > 0) {
         this.fragments = bbqrResult.parts;
         this.setState({ format: 'bbqr' });

--- a/screen/send/ScanQRCode.js
+++ b/screen/send/ScanQRCode.js
@@ -206,30 +206,21 @@ const ScanQRCode = () => {
   };
 
   // Handle BBQr multi-part QR codes
+  // BBQr frame format: B$ + encoding(1) + fileType(1) + total(2 base36) + index(2 base36) + data
   const _onReadBBQrAnimatedQRCode = part => {
     try {
-      // Parse BBQr format: BBQr:P0/1#data or BBQR:P0/1#data
-      const match = part.match(/^BBQr:?(P\d+)\/(\d+)(#|$)/i);
-      if (!match) {
-        console.log('[BBQr] Invalid format, trying full decode');
-        // Try to join without parsing
-        const result = joinQRs([part]);
-        if (result && result.raw) {
-          const psbtBase64 = Buffer.from(result.raw).toString('base64');
-          if (launchedBy) {
-            navigation.navigate({ name: launchedBy, params: {}, merge: true });
-          }
-          onBarScanned({ data: psbtBase64 });
-          return;
-        }
+      const encoding = part[2];
+      const fileType = part[3];
+      const total = parseInt(part.slice(4, 6), 36);
+      const currentIndex = parseInt(part.slice(6, 8), 36);
+
+      if (isNaN(total) || isNaN(currentIndex)) {
+        console.warn('[BBQr] Could not parse header from:', part.slice(0, 10));
         return;
       }
 
-      const currentIndex = parseInt(match[1].replace('P', ''));
-      const total = parseInt(match[2]);
-      
-      console.log('[BBQr] Part', currentIndex + 1, 'of', total);
-      
+      console.log(`[BBQr] Part ${currentIndex + 1} of ${total} (type=${fileType}, enc=${encoding})`);
+
       // Store the QR part
       const newBbqrData = { ...bbqrData };
       newBbqrData[currentIndex] = part;
@@ -240,20 +231,26 @@ const ScanQRCode = () => {
       // Check if we have all parts
       if (Object.keys(newBbqrData).length === total) {
         console.log('[BBQr] All parts received, joining...');
-        // Join all QR parts
         const parts = [];
         for (let i = 0; i < total; i++) {
           parts.push(newBbqrData[i]);
         }
-        
+
         const result = joinQRs(parts);
         if (result && result.raw) {
-          const psbtBase64 = Buffer.from(result.raw).toString('base64');
-          console.log('[BBQr] Joined PSBT, length:', psbtBase64.length);
+          let data;
+          if (result.fileType === 'P') {
+            // PSBT — convert raw bytes to base64
+            data = Buffer.from(result.raw).toString('base64');
+          } else {
+            // Text-based (xpub, JSON, etc.) — decode as UTF-8
+            data = Buffer.from(result.raw).toString('utf8');
+          }
+          console.log(`[BBQr] Joined ${result.fileType}, length: ${data.length}`);
           if (launchedBy) {
             navigation.navigate({ name: launchedBy, params: {}, merge: true });
           }
-          onBarScanned({ data: psbtBase64 });
+          onBarScanned({ data });
         }
       }
     } catch (error) {
@@ -292,9 +289,9 @@ const ScanQRCode = () => {
       return _onReadUniformResource(ret.data);
     }
 
-    // Check for BBQr format (multi-part PSBT)
-    if (ret.data.toUpperCase().startsWith('BBQR') || ret.data.toUpperCase().startsWith('BBQR:') || /^BBQR:P\d+\/\d+/.test(ret.data.toUpperCase())) {
-      console.log('[BBQr] Detected BBQr format, adding to multi-part QR');
+    // Check for BBQr format (frames start with "B$")
+    if (ret.data.startsWith('B$')) {
+      console.log('[BBQr] Detected BBQr frame');
       return _onReadBBQrAnimatedQRCode(ret.data);
     }
 

--- a/src/helpers/bbqrHelper.ts
+++ b/src/helpers/bbqrHelper.ts
@@ -1,70 +1,55 @@
 // BBQr helper for parsing xpub/PSBT from QR codes
-import { detectFileType, joinQRs } from 'bbqr';
-
-interface BBQrResult {
-    isBBQr: boolean;
-    fileType?: string;
-    data?: string;
-    raw?: Uint8Array;
-}
+// BBQr frame format: B$ + encoding(1) + fileType(1) + total(2 base36) + index(2 base36) + data
+import { joinQRs } from 'bbqr';
 
 /**
- * Check if scanned QR data is BBQr format
- * BBQr format typically starts with header like "BBQR:" or specific pattern
+ * Check if scanned QR data is BBQr format.
+ * BBQr frames always start with "B$".
  */
 export const isBBQrFormat = (data: string): boolean => {
-    if (!data) return false;
-    
-    // BBQr QR codes typically have these patterns:
-    // - Start with "BBQR" or "BBQr"
-    // - Multi-part QR codes with format like "BBQr:P0/1#..."
-    const trimmed = data.trim().toUpperCase();
-    return trimmed.startsWith('BBQR') || 
-           trimmed.startsWith('BBQR:') ||
-           /^BBQR:P\d+\/\d+/.test(trimmed) ||   // PSBT multi-part
-           /^BBQr:P\d+\/\d+/.test(trimmed);
+    if (!data || data.length < 8) return false;
+    return data.startsWith('B$');
 };
 
 /**
- * Try to detect file type from BBQr data
+ * Parse BBQr frame header to extract metadata.
+ * Returns null if not a valid BBQr frame.
  */
-export const detectBBQrFileType = (data: string): BBQrResult => {
+export const parseBBQrHeader = (data: string): {
+    encoding: string;
+    fileType: string;
+    total: number;
+    index: number;
+} | null => {
+    if (!isBBQrFormat(data)) return null;
     try {
-        const detected = detectFileType(data);
-        return {
-            isBBQr: true,
-            fileType: detected.fileType,
-            data: data,
-            raw: detected.raw,
-        };
-    } catch (e) {
-        // Not BBQr format or parse error
-        return { isBBQr: false };
+        const encoding = data[2]; // H, 2, or Z
+        const fileType = data[3]; // P, T, J, U, B
+        const total = parseInt(data.slice(4, 6), 36);
+        const index = parseInt(data.slice(6, 8), 36);
+        if (isNaN(total) || isNaN(index)) return null;
+        return { encoding, fileType, total, index };
+    } catch {
+        return null;
     }
 };
 
 /**
- * Check if data is a valid xpub (standard or BBQr encoded)
+ * Check if data is a valid xpub (standard formats).
  */
 export const isValidXpub = (data: string): boolean => {
     const trimmed = data.trim().toLowerCase();
-    return trimmed.startsWith('xpub') || 
-           trimmed.startsWith('ypub') || 
+    return trimmed.startsWith('xpub') ||
+           trimmed.startsWith('ypub') ||
            trimmed.startsWith('zpub') ||
-           trimmed.startsWith('vpub') ||  // testnet
-           trimmed.startsWith('upub') ||
-           trimmed.startsWith('zpub');
+           trimmed.startsWith('vpub') ||
+           trimmed.startsWith('upub');
 };
 
 /**
- * Extract xpub from various formats
+ * Extract xpub from various formats.
  */
 export const extractXpub = (data: string): string | null => {
-    // First try direct xpub
-    const xpubMatch = data.match(/(xpub|ypub|zpub|vpub|upub|ypub)[a-zA-Z0-9]+/i);
-    if (xpubMatch) {
-        return xpubMatch[0];
-    }
-    
-    return null;
+    const xpubMatch = data.match(/(xpub|ypub|zpub|vpub|upub)[a-zA-Z0-9]+/i);
+    return xpubMatch ? xpubMatch[0] : null;
 };

--- a/src/screens/ConnectColdStorage/index.tsx
+++ b/src/screens/ConnectColdStorage/index.tsx
@@ -19,7 +19,7 @@ import loc from '../../../loc';
 import createHash from "create-hash";
 import { BlueURDecoder, decodeUR, extractSingleWorkload } from "../../../blue_modules/ur";
 import { BlueText } from "BlueComponents";
-import { isBBQrFormat, extractXpub, isValidXpub, detectBBQrFileType } from "@Cypher/helpers/bbqrHelper";
+import { extractXpub, isValidXpub } from "@Cypher/helpers/bbqrHelper";
 const fs = require('../../../blue_modules/fs');
 const Base43 = require('../../../blue_modules/base43');
 const bitcoin = require('bitcoinjs-lib');
@@ -92,30 +92,16 @@ export default function ConnectColdStorage({ route, navigation }: Props) {
 
     const handleImport = async (textToImport: string) => {
         console.log('textToImport: ', textToImport)
-        
-        // Check if it's BBQr format first
-        let importData = textToImport;
-        
-        if (isBBQrFormat(textToImport)) {
-            console.log('Detected BBQr format!');
-            const bbqrResult = detectBBQrFileType(textToImport);
-            console.log('BBQr file type:', bbqrResult.fileType);
-            
-            // Try to extract xpub from BBQr data
-            const extractedXpub = extractXpub(textToImport);
-            if (extractedXpub) {
-                importData = extractedXpub;
-                console.log('Extracted xpub from BBQr:', extractedXpub);
-            }
-        }
-        
+
+        // Try to extract xpub from the data (handles both direct xpub and embedded xpub in descriptors)
+        const extractedXpub = extractXpub(textToImport);
+        const importData = extractedXpub || textToImport;
         const cleanedText = importData.replace(/\[.*\]/, '');
-        
-        // Support standard xpub formats + BBQr extracted
+
         const isValid = isValidXpub(cleanedText);
         console.log('isValid: ', isValid)
         if (!isValid) {
-            Alert.alert('Invalid Xpub', 'Please scan a valid xpub QR code (or BBQr format).');
+            Alert.alert('Invalid Xpub', 'Please scan a valid xpub, ypub, or zpub QR code.');
             return;
         }
 


### PR DESCRIPTION
## Summary
- **Fix BBQr header detection**: use correct `B$` prefix per BBQr spec instead of wrong `BBQR`/`BBQR:` pattern
- **Fix `splitQRs` API calls**: pass `Uint8Array` + `fileType` as required by bbqr v1.2 (was passing raw string with wrong signature)
- **Fix ScanQRCode BBQr joining**: parse real header format, handle PSBT vs text output types
- **Clean up ConnectColdStorage**: remove broken single-frame BBQr detection
- **Move MAX button** from CustomKeyboard to EditAmount total row

## Test plan
- [ ] Scan a standard xpub/zpub QR → cold vault creation still works
- [ ] Scan a BBQr-encoded xpub (multi-frame) → cold vault creation works
- [ ] Display unsigned PSBT as QR → UR format shown, BBQr fallback works
- [ ] Scan a BBQr-encoded signed PSBT → transaction broadcasts correctly
- [ ] MAX button in send flow appears next to total and works correctly