### PR TITLE
security: stop leaking OAuth data to logs/Bugsnag; enforce iOS ATS (H1 + H3)

### DIFF
--- a/blue_modules/analytics.js
+++ b/blue_modules/analytics.js
@@ -21,6 +21,29 @@ if (process.env.NODE_ENV !== 'development') {
 
     Bugsnag.start({
       collectUserIp: false,
+      // Don't record console.* as breadcrumbs (omit 'log'): the app logs
+      // around auth and payment flows, and console breadcrumbs would ship
+      // that context (including tokens) with any later crash report.
+      enabledBreadcrumbTypes: ['navigation', 'request', 'process', 'user', 'state', 'error', 'manual'],
+      // Default redactedKeys is only ['password']; widen it so secret-shaped
+      // keys are scrubbed from metadata and breadcrumbs before upload.
+      redactedKeys: [
+        'password',
+        /token/i,
+        /secret/i,
+        'accessToken',
+        'refreshToken',
+        'codeVerifier',
+        'authorizationCode',
+        'mnemonic',
+        'seed',
+        'privateKey',
+        'xprv',
+        'passphrase',
+        'otp',
+        'apiKey',
+        'authorization',
+      ],
       user: {
         id: uniqueID,
       },

--- a/ios/BlueWallet/Info.plist
+++ b/ios/BlueWallet/Info.plist
@@ -136,7 +136,7 @@
 	<key>NSAppTransportSecurity</key>
 	<dict>
 		<key>NSAllowsArbitraryLoads</key>
-		<true/>
+		<false/>
 		<key>NSExceptionDomains</key>
 		<dict>
 			<key>localhost</key>

--- a/src/screens/CheckingAccountLogin/index.tsx
+++ b/src/screens/CheckingAccountLogin/index.tsx
@@ -152,7 +152,6 @@ export default function CheckingAccountLogin() {
   const handleStrikeLogin = async () => {
     try {
       const result = await authorize(config);
-      console.log("Access Token:", result);
       const reStrikeTokenExchange = await strikeTokenExchange(result.authorizationCode, result.codeVerifier || '');
       setStrikeToken(reStrikeTokenExchange.access_token);
       setStrikeAuth(true);
@@ -162,8 +161,6 @@ export default function CheckingAccountLogin() {
       const payload = Buffer.from(tokenParts[1], "base64").toString("utf8");
       const signature = tokenParts[2];
       const decoded = JSON.parse(payload);
-      console.log("decoded", decoded);
-      console.log("signature: ", signature);
       setStrikeMe(decoded);
       setAllBTCWallets([...temp, "STRIKE"]);
       if(FirstTimeLightning){
@@ -192,7 +189,6 @@ export default function CheckingAccountLogin() {
         code: code,
         verifier: verifier,
       };      
-      console.log('details to send:', details);
       const response = await fetch('https://cypherbox-backend.onrender.com/oauth/start', {
         method: 'POST',
         headers: {
@@ -204,7 +200,6 @@ export default function CheckingAccountLogin() {
 
       const responseJSON = await response.json();
       if (responseJSON.success) {
-        console.log("Response Body:", responseJSON);
         return responseJSON.data;
       } else {
         SimpleToast.show('Strike authentication failed.', SimpleToast.SHORT);


### PR DESCRIPTION

H1 (token leakage):
- Remove ungated console.log of the OAuth result and token-exchange response body in CheckingAccountLogin. These printed access/refresh tokens to logcat/Console and were captured as Bugsnag console breadcrumbs, shipping live tokens off-device in crash reports.
- Harden Bugsnag init (blue_modules/analytics.js): drop 'log' from enabledBreadcrumbTypes so console.* is no longer recorded as breadcrumbs, and widen redactedKeys (was only ['password']) to scrub token/secret/seed-shaped keys before upload.

H3 (iOS transport security):
- Set NSAllowsArbitraryLoads=false in ios/BlueWallet/Info.plist so ATS is enforced on production endpoints (Strike, CoinOS, esplora, Ark ASP). Existing per-domain exceptions (localhost/onion/tailscale/ts.net) are retained for local-node + Tor + Tailscale cleartext.

Ref: .claude/SECURITY_AUDIT_2026-06-10.md (H1, H3). This is the re-application of a local-only commit (orig 2f97b62, Mythos session 2026-06-10) that never reached origin; content is byte-identical to the original.