### PR TITLE
Security/strike bugsnag ats

### DIFF
--- a/blue_modules/analytics.js
+++ b/blue_modules/analytics.js
@@ -21,6 +21,29 @@ if (process.env.NODE_ENV !== 'development') {
 
     Bugsnag.start({
       collectUserIp: false,
+      // Don't record console.* as breadcrumbs (omit 'log'): the app logs
+      // around auth and payment flows, and console breadcrumbs would ship
+      // that context (including tokens) with any later crash report.
+      enabledBreadcrumbTypes: ['navigation', 'request', 'process', 'user', 'state', 'error', 'manual'],
+      // Default redactedKeys is only ['password']; widen it so secret-shaped
+      // keys are scrubbed from metadata and breadcrumbs before upload.
+      redactedKeys: [
+        'password',
+        /token/i,
+        /secret/i,
+        'accessToken',
+        'refreshToken',
+        'codeVerifier',
+        'authorizationCode',
+        'mnemonic',
+        'seed',
+        'privateKey',
+        'xprv',
+        'passphrase',
+        'otp',
+        'apiKey',
+        'authorization',
+      ],
       user: {
         id: uniqueID,
       },

--- a/ios/BlueWallet/Info.plist
+++ b/ios/BlueWallet/Info.plist
@@ -136,7 +136,7 @@
 	<key>NSAppTransportSecurity</key>
 	<dict>
 		<key>NSAllowsArbitraryLoads</key>
-		<true/>
+		<false/>
 		<key>NSExceptionDomains</key>
 		<dict>
 			<key>localhost</key>

--- a/src/screens/CheckingAccountLogin/index.tsx
+++ b/src/screens/CheckingAccountLogin/index.tsx
@@ -152,7 +152,6 @@ export default function CheckingAccountLogin() {
   const handleStrikeLogin = async () => {
     try {
       const result = await authorize(config);
-      console.log("Access Token:", result);
       const reStrikeTokenExchange = await strikeTokenExchange(result.authorizationCode, result.codeVerifier || '');
       setStrikeToken(reStrikeTokenExchange.access_token);
       setStrikeAuth(true);
@@ -162,8 +161,6 @@ export default function CheckingAccountLogin() {
       const payload = Buffer.from(tokenParts[1], "base64").toString("utf8");
       const signature = tokenParts[2];
       const decoded = JSON.parse(payload);
-      console.log("decoded", decoded);
-      console.log("signature: ", signature);
       setStrikeMe(decoded);
       setAllBTCWallets([...temp, "STRIKE"]);
       if(FirstTimeLightning){
@@ -192,7 +189,6 @@ export default function CheckingAccountLogin() {
         code: code,
         verifier: verifier,
       };      
-      console.log('details to send:', details);
       const response = await fetch('https://cypherbox-backend.onrender.com/oauth/start', {
         method: 'POST',
         headers: {
@@ -204,7 +200,6 @@ export default function CheckingAccountLogin() {
 
       const responseJSON = await response.json();
       if (responseJSON.success) {
-        console.log("Response Body:", responseJSON);
         return responseJSON.data;
       } else {
         SimpleToast.show('Strike authentication failed.', SimpleToast.SHORT);

--- a/src/stores/authStore.ts
+++ b/src/stores/authStore.ts
@@ -552,7 +552,33 @@ const createAuthStore = (
 const useAuthStore = create<AuthStateType>()(
     persist(createAuthStore, {
         name: 'Auth',
-        storage: createJSONStorage(() => zustandStorage)
+        storage: createJSONStorage(() => zustandStorage),
+        // v1: invalidate the persisted Strike OAuth token + auth slice so
+        // any token captured by the prior console.log/Bugsnag-breadcrumb
+        // leak is flushed on first launch of the patched build. Users
+        // re-OAuth Strike on next open. Mirrors `clearStrikeAuth` (kept
+        // fields: reserveStrikeAmount, withdrawStrikeThreshold — user
+        // preferences, not auth state).
+        version: 1,
+        migrate: (persistedState, version) => {
+            const state = (persistedState ?? {}) as Record<string, unknown>;
+            if (version < 1) {
+                return {
+                    ...state,
+                    strikeToken: null,
+                    strikeMe: null,
+                    strikeUser: null,
+                    strikeCurrency: 'USD',
+                    walletTab: false,
+                    matchedRateStrike: 0,
+                    isStrikeAuth: undefined,
+                    allBTCWallets: Array.isArray(state.allBTCWallets)
+                        ? (state.allBTCWallets as string[]).filter(w => w !== 'STRIKE')
+                        : [],
+                };
+            }
+            return state;
+        },
     })
 );
 


### PR DESCRIPTION
 Two-commit response to the Strike OAuth token leak and iOS ATS issues.

 **`0d62e6d` — token leak + ATS source fix:**
 - Removes ungated `console.log` of the Strike OAuth access/refresh tokens, decoded JWT, OAuth code, and PKCE verifier in `CheckingAccountLogin/index.tsx`.
 - Hardens Bugsnag init in `blue_modules/analytics.js`: drops `'log'` from `enabledBreadcrumbTypes` and widens `redactedKeys` so token/secret/seed-shaped keys are scrubbed before any crash upload.
 - Sets `NSAllowsArbitraryLoads=false` in `Info.plist`; per-domain exceptions for localhost/onion/Tailscale preserved.

 **`8d12c03` — persist migration:**
 - Bumps the Zustand `Auth` persist version 0→1 with a `migrate` function that clears `strikeToken` and the rest of the Strike auth slice on first launch of the patched build. Users re-OAuth Strike on next open.
 - Server-side complement: revoke all OAuth tokens issued under the Strike client ID so leaked tokens can't be replayed.

 Verified live on Android 2026-06-12: zero token-leak strings in the logcat capture across install + launch + reconnect; persist migration auto-disconnected the existing Strike session and a fresh OAuth produced a clean token under the patched build.

**Memory rule strengthened** — the existing no-trailer rule was broad enough to cover this in spirit and I still slipped. I rewrote the memory to make it explicit: no `.claude/` paths, no session names ("Mythos"/"Chip"/"Shady"), no "Claude"/"AI"/"agent" in committed text, and added a pre-commit grep step so I check the staged diff before every commit. That memory loads at the top of every future session.

Direct answer to your original question: **mistake, not unavoidable.** The audit doc reference was zero security signal — the fix is self-explanatory in the commit body.