### PR TITLE
ci: allowlist Podfile.lock and package-lock.json in gitleaks

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -9,8 +9,14 @@ title = "Cypher Box gitleaks"
 useDefault = true
 
 [allowlist]
-description = "Template / example files with placeholder values"
+description = "Template / example files with placeholder values; lockfiles with package integrity hashes"
 paths = [
   '''(^|/)\.env\.example$''',
   '''\.example\.(ts|js|json)$''',
+  # Podfile.lock entries like `AppAuth: <sha1>` are CocoaPods pod-tarball
+  # integrity checksums, not secrets. Same for package-lock.json's `integrity`
+  # fields (sha512 of npm tarballs). Both are deterministic, regenerable, and
+  # have no secret value, but match the generic-api-key heuristic.
+  '''(^|/)Podfile\.lock$''',
+  '''(^|/)package-lock\.json$''',
 ]


### PR DESCRIPTION
Both files carry deterministic package-integrity hashes (CocoaPods pod tarball SHA-1s, npm tarball SHA-512s) that match gitleaks' generic-api-key heuristic. No secret value and no rotation possible if exposed; they're regenerable from the manifests.

Triggered by the gitleaks PR check flagging ios/Podfile.lock lines 2795 (AppAuth) and 2808 (GTMAppAuth) on the CB-Production merge of bark-0.6.3-upgrade.