### PR TITLE
Merge qa-apple-inapp-browser into CB-Production (vc26 + iOS 13)

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -99,7 +99,7 @@ android {
         applicationId "io.cypherbox.btc"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 25
+        versionCode 26
         versionName "0.1.1"
         testBuildType System.getProperty('testBuildType', 'debug')
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -99,7 +99,7 @@ android {
         applicationId "io.cypherbox.btc"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 24
+        versionCode 25
         versionName "0.1.1"
         testBuildType System.getProperty('testBuildType', 'debug')
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'

--- a/ios/BlueWallet/Info.plist
+++ b/ios/BlueWallet/Info.plist
@@ -120,7 +120,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>12</string>
+	<string>13</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSApplicationCategoryType</key>

--- a/src/screens/Ark/ArkCapsulesInfoScreen/index.tsx
+++ b/src/screens/Ark/ArkCapsulesInfoScreen/index.tsx
@@ -52,14 +52,10 @@ export default function ArkCapsulesInfoScreen() {
                         off, no reminders fire and you alone are responsible for opening the
                         app and refreshing your capsules before they expire.
                     </Body>
-                    <StatusRow
-                        title="Last-resort rescue to Strike or CoinOS"
-                        body="If a capsule is within roughly 12 hours of expiring and still hasn't refreshed, Cypher Box automatically forwards those funds over Lightning to your connected Strike or CoinOS balance (Strike first, CoinOS as backup). Your money is safe there as a custodial balance, which is far better than letting the capsule expire and forcing a costly on-chain recovery. You can move it back into Ark whenever you like."
-                    />
                     <Body>
-                        This rescue only runs if you have Strike or CoinOS connected. If
-                        neither is connected, the reminder notifications are your only
-                        safety net.
+                        The reminders are your safety net. Refreshing only works while the
+                        app is open, so tapping a reminder is what keeps your capsules
+                        alive.
                     </Body>
                 </Section>
 
@@ -80,23 +76,23 @@ export default function ArkCapsulesInfoScreen() {
                 <Section title="What the capsule colors mean">
                     <ColorRow
                         color="#4ADE80"
-                        label="Green — 21+ days left"
+                        label="Green: 21+ days left"
                         body="Fresh. Nothing to do."
                     />
                     <ColorRow
                         color={colors.ark?.light ?? "#F2C94C"}
-                        label="Yellow — 14–20 days left"
-                        body="Past the midpoint. We'll refresh it before it gets urgent."
+                        label="Yellow: 14-20 days left"
+                        body="Past the midpoint. Worth refreshing next time you're in the app."
                     />
                     <ColorRow
                         color="#FB923C"
-                        label="Orange — 7–13 days left"
-                        body="Within the refresh window. Cypher Box will roll it in on the next refresh."
+                        label="Orange: 7-13 days left"
+                        body="Within the refresh window. Refresh it now, before the reminders start."
                     />
                     <ColorRow
                         color={colors.redLight ?? "#FF6B6B"}
-                        label="Red — less than 7 days left"
-                        body="Needs refresh soon. After it expires, the server can claim the capsule."
+                        label="Red: less than 7 days left"
+                        body="Needs refresh now. Reminders are firing, tap one to refresh. After it expires, the server can claim the capsule."
                     />
                 </Section>
 
@@ -111,7 +107,7 @@ export default function ArkCapsulesInfoScreen() {
                     />
                     <StatusRow
                         title="In-flight"
-                        body="Being used in another operation — an outgoing send, withdrawal, or boarding. Same kind of brief lock as Refreshing."
+                        body="Being used in another operation: an outgoing send, withdrawal, or boarding. Same kind of brief lock as Refreshing."
                     />
                 </Section>
 

--- a/src/services/ark/emergencyCustodialSweep.ts
+++ b/src/services/ark/emergencyCustodialSweep.ts
@@ -64,6 +64,18 @@ import {
 export const CUSTODIAL_SWEEP_THRESHOLD = 72;
 
 /**
+ * HARD KILL-SWITCH. The custodial sweep was an experimental safety net that
+ * never shipped as a product feature: it depends on background execution
+ * windows the OS doesn't reliably grant, and the supported expiry story is
+ * the 5 tap-to-refresh reminder notifications. User-facing docs state that
+ * reminders are the only safety net, so silently moving funds to a
+ * custodian here would contradict what users were told. Disabled at the
+ * entry point (covers all scheduler call sites) pending full removal of
+ * the dead background-refresh machinery.
+ */
+export const CUSTODIAL_SWEEP_ENABLED = false;
+
+/**
  * LN routing fee reserve, subtracted off the gross before sweeping so the
  * Ark `payLightningInvoice` doesn't fail with "not enough balance" (amount
  * + fee > spendable).
@@ -115,6 +127,7 @@ let sweepInFlight = false;
 // ---------------------------------------------------------------------
 
 export type EmergencySweepOutcome =
+    | 'disabled'
     | 'no_handle'
     | 'no_imminent_vtxos'
     | 'pending_round_conflict'
@@ -217,6 +230,10 @@ function pushSweepAlert(title: string, message: string): void {
 export async function runEmergencyCustodialSweep(
     trigger: 'scheduled' | 'push' | 'foreground' | 'manual-test' = 'scheduled',
 ): Promise<EmergencySweepResult> {
+    if (!CUSTODIAL_SWEEP_ENABLED) {
+        console.log('[Ark sweep] disabled by kill-switch (trigger=' + trigger + ')');
+        return { outcome: 'disabled' };
+    }
     if (sweepInFlight) {
         console.log('[Ark sweep] re-entry blocked — previous attempt still in flight');
         return { outcome: 'reentry_blocked' };


### PR DESCRIPTION
Brings CB-Production to the vc26 release train: custodial-sweep kill-switch, capsule info sheet rewrite, versionCode 26, iOS CFBundleVersion 13.

Provenance: tag v0.1.1-vc26, reproducible AAB SHA-256 fae13de8d8bf42e0c83cac744e06ad55e6132eb5ca4ec1d892d0c0b549c25c90 (CI run 28697151091).