### PR TITLE
docs(readme): trim intro tagline

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 **Website:** [cypherbox.io](https://cypherbox.io) · **Community:** [Telegram](https://t.me/BitcoinUserSupport) · **Email:** info@cypherbox.io
 
-Cypher Box walks you up the self-custody ladder: start with an easy custodial Lightning account, graduate to a non-custodial Lightning vault on the Ark protocol, and land in full on-chain cold storage. One app, three rails, no lectures.
+Cypher Box walks you up the self-custody ladder: start with an easy custodial Lightning account, graduate to a non-custodial Lightning vault on the Ark protocol, and land in full on-chain cold storage.
 
 Forked from [BlueWallet](https://github.com/BlueWallet/BlueWallet) 6.5.1. Built with React Native + Electrum, powered by **Strike**, **Coinos**, and **Second's Bark SDK**.
 


### PR DESCRIPTION
One-line follow-up that missed the #109/#110 window: drops the intro tagline sentence. After this, main and the working branch are identical.