### PR TITLE
Lightning swap: Strike Max fee reserve + Ark open-retry diagnostics

### DIFF
--- a/src/services/ark/restore.ts
+++ b/src/services/ark/restore.ts
@@ -87,12 +87,20 @@ export async function restoreArkWalletFromDisk(): Promise<ArkRestoreResult> {
             return { restored: true };
         } catch (err) {
             lastErr = err as Error;
-            const detail = `${(err as { tag?: string })?.tag ?? ''} ${(err as Error)?.message ?? ''}`;
+            const e = err as { tag?: string; message?: string; inner?: { errorMessage?: string; message?: string } };
+            const detail = `${e?.tag ?? ''} ${e?.message ?? ''}`;
             const transient = /ServerConnection|Connection|timeout|timed out|network/i.test(detail);
             if (!transient || attempt === OPEN_ATTEMPTS) break;
             if (__DEV__) {
+                // Stringify the inner UniFFI payload inline: the tag alone
+                // (BarkError.ServerConnection) hides whether the failure was
+                // DNS, TCP, TLS, or a gRPC status from the ASP, and object
+                // args don't survive log forwarding as text.
                 console.log(
-                    `[Ark restore] open attempt ${attempt}/${OPEN_ATTEMPTS} failed (${detail.trim()}); retrying in ${OPEN_RETRY_DELAY_MS}ms`,
+                    `[Ark restore] open attempt ${attempt}/${OPEN_ATTEMPTS} failed (${detail.trim()}); ` +
+                    `inner=${e?.inner?.errorMessage ?? e?.inner?.message ?? 'n/a'} ` +
+                    `raw=${JSON.stringify(e, Object.getOwnPropertyNames(e ?? {}))}; ` +
+                    `retrying in ${OPEN_RETRY_DELAY_MS}ms`,
                 );
             }
             await new Promise((r) => setTimeout(r, OPEN_RETRY_DELAY_MS));

--- a/src/services/lightningSwap/providers/strike.ts
+++ b/src/services/lightningSwap/providers/strike.ts
@@ -226,6 +226,24 @@ const strikeProvider: LightningSwapProvider = {
     // want to surface a pre-swap fee for Strike, the right approach
     // is to merge quote+execute into payInvoice (it already is) and
     // expose a `dry-run` quote here.
+
+    /**
+     * Max-button headroom only (same contract as the Coinos provider's
+     * reserve). Strike rejects a payment quote outright with
+     * `422 BALANCE_TOO_LOW` when `amount + routing fee` exceeds the
+     * balance, so a Max swap with zero headroom fails before anything
+     * is attempted (observed live 2026-07-06: balance 22,642, Max
+     * quote refused). Strike doesn't expose the fee pre-quote, so this
+     * is a calibrated buffer, not a price: 1% with a 10-sat floor —
+     * deliberately fatter than Coinos's 0.6% because we have no
+     * empirical fee data for Strike yet, and the unspent remainder
+     * stays in the user's Strike balance rather than being lost. If
+     * live QA shows Strike's realised fees are consistently smaller,
+     * tighten this the same way the Coinos reserve was calibrated.
+     */
+    async maxFeeReserve(amountSats) {
+        return Math.max(10, Math.ceil(amountSats * 0.01));
+    },
 };
 
 register(strikeProvider);


### PR DESCRIPTION
Two small fixes from tonight's on-device QA:

- **Strike Max reserve**: swapping Max from Strike always failed with 422 BALANCE_TOO_LOW because the full balance left no headroom for Strike's routing fee. Reserve 1% (10-sat floor), same mechanism as the Coinos reserve. Verified live: Max quote passes and the swap completes.
- **Ark open-retry logging**: include the inner UniFFI error payload when Wallet.open retries, so server-connection outages are diagnosable from the log stream (tonight's 10-attempt outage only ever printed the variant tag).