### PR TITLE
feat(ark): surface expired capsules and escalate failed refreshes near expiry

### DIFF
--- a/src/components/ArkWallet/index.tsx
+++ b/src/components/ArkWallet/index.tsx
@@ -324,6 +324,10 @@ export default function ArkWallet({
             if (v.expiryHeight === 0) continue;
             if (v.state.toLowerCase() === 'locked') continue;
             const blocks = v.expiryHeight - arkChainTipHeight;
+            // Skip already-expired VTXOs (they stay in the store so the
+            // Capsules tab can render them) — "refresh soon" is wrong
+            // advice for funds that are already unrecoverable.
+            if (blocks <= 0) continue;
             if (blocks < minBlocks) minBlocks = blocks;
         }
         if (!isFinite(minBlocks)) return null;

--- a/src/custom-hooks/useArkSync.ts
+++ b/src/custom-hooks/useArkSync.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
-import { AppState, AppStateStatus, InteractionManager, Platform } from 'react-native';
+import { Alert, AppState, AppStateStatus, InteractionManager, Platform } from 'react-native';
 
 import {
     applyExpiredVtxoFilter,
@@ -30,6 +30,9 @@ import {
     writeArkAutoBackup,
 } from '@Cypher/services/ark';
 import { processArkMovementsForActivity } from '@Cypher/services/ark/movementsActivity';
+// Imported from the file path directly (not the @Cypher/services/ark
+// barrel) — the barrel doesn't re-export the expiry module.
+import { formatBlocksUntil } from '@Cypher/services/ark/expiry';
 import useAuthStore from '@Cypher/stores/authStore';
 import { recordEvent } from '@Cypher/stores/eventLogStore';
 import {
@@ -97,6 +100,24 @@ const URGENCY_THRESHOLD_BLOCKS = Math.round(
 // telemetry buffer would fill with no-ops.
 const FOREGROUND_SWEEP_MIN_GAP_MS = 5 * 60 * 1000;
 let lastForegroundSweepAt = 0;
+
+// --- Refresh-failure escalation near expiry --------------------------------
+//
+// The expiry-warning notifications cover "time is running out" and the
+// stuck-refresh banner covers "a round is wedged". Neither covers the
+// failure mode that actually lost user funds (support case 2026-07-11):
+// every refresh SUBMISSION fails outright (infra outage, IP-blocked
+// esplora, captive portal) while the expiry clock runs down — 12+ failed
+// rounds over 3 days with under 2 days left, and the app never raised
+// its voice. Once this many consecutive submissions have failed
+// (arkRefreshFailStreak, maintained in services/ark/refresh.ts across
+// every refresh path) AND a spendable VTXO is inside the urgency window,
+// a blocking Alert surfaces the rescue playbook in the order that works
+// in practice: switch networks and retry, then Emergency Exit while
+// there is still time. Re-shown at most once per gap window so the sync
+// tick doesn't nag while the user is following the steps.
+const REFRESH_FAIL_ESCALATE_STREAK = 3;
+const REFRESH_FAIL_ALERT_GAP_MS = 6 * 60 * 60 * 1000;
 
 // --- Self-heal for a failed boot open -------------------------------------
 //
@@ -424,34 +445,37 @@ export default function useArkSync(): UseArkSync {
                 setArkBalanceDetail(filteredBalance);
             }
             if (vtxos) {
-                // Filter past-expiry VTXOs out of the live capsule list.
-                // The SDK reports them as Spendable until the ASP actually
-                // sweeps them, but they cannot participate in a refresh
-                // round (the ASP rejects expired inputs) and surfacing
-                // them as actionable capsules misleads users: the funds
-                // are already lost. Arkoor (expiryHeight === 0) stay,
-                // they inherit expiry from their parent and the SDK
-                // hasn't resolved it yet. The History tab still shows
-                // their lifecycle as a record, so the loss is visible
-                // there instead of cluttering the active capsule list.
-                const visibleSpendable =
+                // Past-expiry VTXOs stay IN the list. The SDK reports them
+                // as Spendable until the ASP actually sweeps them; they
+                // can't join a refresh round (the ASP rejects expired
+                // inputs) and the funds are effectively lost. An earlier
+                // iteration filtered them out here, which made a wallet
+                // whose only capsule expired read as an unexplained zero
+                // balance with an empty Capsules tab (real support case,
+                // 2026-07-11: a 1000-sat VTXO expired during an infra
+                // outage and the app showed nothing at all). The Capsules
+                // tab now renders them as a greyed non-actionable
+                // "Expired" row with an explainer; the headline balance
+                // still excludes their sats via applyExpiredVtxoFilter
+                // above. Consumers that ACT on VTXOs (refresh batches,
+                // urgency sweep, dust consolidation, expiry warnings)
+                // each skip expiryHeight <= tip themselves.
+                const expiredCount =
                     typeof tip === 'number'
                         ? vtxos.spendable.filter(
-                              (v) => v.expiryHeight === 0 || v.expiryHeight > tip,
-                          )
-                        : vtxos.spendable;
+                              (v) => v.expiryHeight !== 0 && v.expiryHeight <= tip,
+                          ).length
+                        : 0;
                 console.log(
                     '[Ark sync] writing',
-                    visibleSpendable.length,
-                    'vtxos to store (of',
                     vtxos.spendable.length,
-                    'spendable,',
+                    'vtxos to store (of',
                     vtxos.all.length,
                     'total;',
-                    vtxos.spendable.length - visibleSpendable.length,
-                    'past-expiry hidden)',
+                    expiredCount,
+                    'past expiry)',
                 );
-                setArkVtxos(visibleSpendable);
+                setArkVtxos(vtxos.spendable);
             } else {
                 console.log('[Ark sync] fetchArkVtxos returned null (no handle)');
             }
@@ -760,13 +784,16 @@ export default function useArkSync(): UseArkSync {
                 }
             }
             let minBlocks = Infinity;
+            // Same minimum but INCLUDING user-deferred VTXOs — the
+            // failure-streak escalation below uses this one. Deferring
+            // auto-refresh ("Use immediately") doesn't make the funds
+            // immune to expiry, so a deferred VTXO still counts when
+            // deciding whether to raise the alarm.
+            let minBlocksAnySpendable = Infinity;
             if (tip !== null && vtxos) {
                 for (const v of vtxos.spendable) {
                     if (v.expiryHeight === 0) continue;
                     if (v.state.toLowerCase() === 'locked') continue;
-                    // User-deferred — skip so the urgency sweep doesn't
-                    // try to refresh a VTXO the user said to leave alone.
-                    if (deferredIds.has(v.id)) continue;
                     const blocks = v.expiryHeight - tip;
                     // Skip already-expired VTXOs. Including them would make
                     // the lazy-refresh sweep fire on dead funds (refresh
@@ -776,6 +803,10 @@ export default function useArkSync(): UseArkSync {
                     // next-most-urgent SPENDABLE-IN-PRACTICE VTXO, not to
                     // already-lost ones.
                     if (blocks <= 0) continue;
+                    if (blocks < minBlocksAnySpendable) minBlocksAnySpendable = blocks;
+                    // User-deferred — skip so the urgency sweep doesn't
+                    // try to refresh a VTXO the user said to leave alone.
+                    if (deferredIds.has(v.id)) continue;
                     if (blocks < minBlocks) minBlocks = blocks;
                 }
             }
@@ -809,6 +840,37 @@ export default function useArkSync(): UseArkSync {
                 void runBackgroundRefresh('foreground').catch((err) => {
                     console.warn('[Ark sync] foreground sweep threw:', err?.message ?? err);
                 });
+            }
+
+            // --- Refresh-failure escalation near expiry ---
+            //
+            // See REFRESH_FAIL_ESCALATE_STREAK above for the rationale.
+            // Blocking Alert, not a toast or banner: this is the last
+            // software intervention between the user and unrecoverable
+            // fund loss, and the two prior warning layers (expiry
+            // notifications, stuck banner) demonstrably weren't loud
+            // enough when refreshes were failing outright.
+            const failStreak = state.arkRefreshFailStreak ?? 0;
+            if (
+                failStreak >= REFRESH_FAIL_ESCALATE_STREAK &&
+                isFinite(minBlocksAnySpendable) &&
+                minBlocksAnySpendable < URGENCY_THRESHOLD_BLOCKS &&
+                Date.now() - (state.arkRefreshFailAlertAt ?? 0) > REFRESH_FAIL_ALERT_GAP_MS
+            ) {
+                useAuthStore.getState().setArkRefreshFailAlertAt(Date.now());
+                console.warn(
+                    '[Ark sync] refresh-failure escalation — failStreak=', failStreak,
+                    'minBlocks=', minBlocksAnySpendable,
+                );
+                Alert.alert(
+                    'Refresh keeps failing',
+                    `Your capsules expire ${formatBlocksUntil(minBlocksAnySpendable)} and your last ` +
+                    `${failStreak} refresh attempts failed. Switch networks (Wi-Fi to cellular, or ` +
+                    'cellular to Wi-Fi) and refresh again. If refresh still fails, use ' +
+                    'Settings → Emergency Exit to move your funds on-chain before they expire. ' +
+                    'Expired capsules are lost forever.',
+                    [{ text: 'OK' }],
+                );
             }
 
             // --- Auto-backup (fire-and-forget, off the critical path) ---

--- a/src/screens/HomeScreen/WalletsView/index.tsx
+++ b/src/screens/HomeScreen/WalletsView/index.tsx
@@ -138,6 +138,10 @@ const WalletsView = forwardRef<WalletsViewHandle, Props>(function WalletsView({
             if (v.expiryHeight === 0) continue;
             if (v.state.toLowerCase() === 'locked') continue;
             const blocks = v.expiryHeight - arkChainTipHeight;
+            // Skip already-expired VTXOs (they stay in the store so the
+            // Capsules tab can render them) — "refresh soon" is wrong
+            // advice for funds that are already unrecoverable.
+            if (blocks <= 0) continue;
             if (blocks < minBlocks) minBlocks = blocks;
         }
         if (!isFinite(minBlocks)) return null;

--- a/src/screens/Strike/CheckingAccountNew/ArkCapsules.tsx
+++ b/src/screens/Strike/CheckingAccountNew/ArkCapsules.tsx
@@ -71,6 +71,23 @@ import ArkOnchainRecoverSection from "./ArkOnchainRecoverSection";
 const VTXO_MAX_DAYS = 28;
 const VTXO_MAX_BLOCKS = Math.round((VTXO_MAX_DAYS * 24 * 60) / AVG_BLOCK_MINUTES);
 
+/**
+ * Expired = past its expiry height and not mid-round. The funds can no
+ * longer be refreshed, sent, or swept (the ASP can claim them at any
+ * time), so expired rows render greyed and non-actionable. Locked rows
+ * are excluded even when their daysLeft reads 0: a Locked VTXO's
+ * expiryHeight is the PRE-refresh leaf's expiry, which legitimately lags
+ * the chain tip while a recovery round is in flight — those keep the
+ * transient "Refreshing" treatment instead.
+ */
+function isExpiredCapsule(r: {
+    daysLeft: number;
+    pendingRound: boolean;
+    recoverability: 'backed-up' | 'needs-backup' | 'in-flight';
+}): boolean {
+    return r.daysLeft <= 0 && !r.pendingRound && r.recoverability !== 'in-flight';
+}
+
 type ExpiryStatus = "green" | "yellow" | "orange" | "red";
 
 interface ExpiryView {
@@ -324,15 +341,39 @@ function VtxoRow({ vtxo, selected, onPress, onRefreshIcon, onCancelIcon, isCance
     // same two-line label since the user-visible behaviour is identical
     // (capsule is locked, unspendable until the operation commits).
     const isTransientForLabel = vtxo.pendingRound || vtxo.recoverability === 'in-flight';
-    const labelColor = isTransientForLabel ? colors.ark.light : view.color;
+    // Expired rows render greyed and non-actionable: grey "Expired"
+    // label, grey amount, no recoverability suffix (a backup can't
+    // resurrect an expired VTXO), badge instead of refresh/select, and
+    // tap opens an explainer instead of toggling selection.
+    const isExpired = isExpiredCapsule(vtxo);
+    const labelColor = isTransientForLabel
+        ? colors.ark.light
+        : isExpired
+            ? '#888'
+            : view.color;
     const labelText = isTransientForLabel
         ? (isCancelling
             ? 'Cancelling\n(takes less than an hour)'
             : 'Refreshing or In-flight\n(takes less than an hour)')
-        : vtxo.unknownExpiry
-            ? vtxo.kind
-            : `${Math.max(0, Math.round(vtxo.daysLeft))}d left`;
+        : isExpired
+            ? 'Expired'
+            : vtxo.unknownExpiry
+                ? vtxo.kind
+                : `${Math.max(0, Math.round(vtxo.daysLeft))}d left`;
     const ringDaysLeft = isTransientForLabel ? VTXO_MAX_DAYS : vtxo.daysLeft;
+
+    // Explainer for expired capsules — the only "action" the row keeps.
+    // Copy matches the header tagline's "lost forever" framing so the
+    // user gets the same story everywhere.
+    const showExpiredExplainer = () => {
+        Alert.alert(
+            'Capsule expired',
+            `This ${vtxo.sats.toLocaleString()}-sat capsule reached its expiry without a successful refresh. ` +
+            'After expiry the Ark server can sweep the funds, and they can no longer be refreshed, sent, or recovered. ' +
+            'Refresh your remaining capsules before they expire, or they are lost forever.',
+            [{ text: 'OK' }],
+        );
+    };
 
     // Recoverability suffix — appended to the existing expiry/state line as
     // a second colored span separated by " - ". Three states drive both
@@ -419,13 +460,12 @@ function VtxoRow({ vtxo, selected, onPress, onRefreshIcon, onCancelIcon, isCance
             )}
             {/* Outer row tap toggles selection. For ANY expired capsule
                 (dust or not) the action area renders EXPIRED instead of
-                a refresh icon / checkbox, so the tap has nothing useful
-                to toggle — disable it to avoid an invisible "selected"
-                state that the user can't see or act on. */}
+                a refresh icon / checkbox, so there's nothing useful to
+                toggle — the tap opens the expiry explainer instead. */}
             <TouchableOpacity
-                activeOpacity={vtxo.daysLeft <= 0 ? 1 : 0.7}
+                activeOpacity={0.7}
                 style={rowStyles.container}
-                onPress={vtxo.daysLeft <= 0 ? undefined : onPress}
+                onPress={isExpired ? showExpiredExplainer : onPress}
             >
                 {/* Trim the coin (ring) column's flex from 2.2 → 1.5 and
                     bump the size column from 1.8 → 2.8 so the time-left +
@@ -437,7 +477,7 @@ function VtxoRow({ vtxo, selected, onPress, onRefreshIcon, onCancelIcon, isCance
                 </View>
                 <View style={[rowStyles.size, { flex: 2.8 }]}>
                     <View style={{ flexDirection: 'row', alignItems: 'center', flexWrap: 'nowrap' }}>
-                        <Text bold style={rowStyles.value}>{BTCAmount}</Text>
+                        <Text bold style={isExpired ? [rowStyles.value, { color: '#888' }] : rowStyles.value}>{BTCAmount}</Text>
                         {/* Dust badge: capsules at or below the on-chain
                             dust limit can't be refreshed (ASP rejects)
                             and create stranded change if used in a send
@@ -454,7 +494,7 @@ function VtxoRow({ vtxo, selected, onPress, onRefreshIcon, onCancelIcon, isCance
                             anymore). Keeps the row's right edge
                             telling the user "this is dead" instead of
                             duplicating the badge in two places. */}
-                        {vtxo.sats <= ARK_VTXO_DUST_SATS && vtxo.daysLeft > 0 && (
+                        {vtxo.sats <= ARK_VTXO_DUST_SATS && !isExpired && (
                             <View
                                 style={{
                                     marginLeft: 6,
@@ -483,12 +523,14 @@ function VtxoRow({ vtxo, selected, onPress, onRefreshIcon, onCancelIcon, isCance
                         message is too important to compete with the days-
                         left text on the same line. Other recoverability
                         states keep the inline " - <text>" layout. */}
-                    {vtxo.recoverability === 'in-flight' ? (
+                    {vtxo.recoverability === 'in-flight' || isExpired ? (
                         // The two-line italic label above already says
                         // "Refreshing or In-flight\n(takes less than an hour)"
                         // so we drop the separate recoverabilityText
                         // suffix on this branch — it'd just say
-                        // "In-flight" again.
+                        // "In-flight" again. Expired rows drop the suffix
+                        // too: "Backed up" next to a dead capsule reads
+                        // as "recoverable", which it is not.
                         <Text bold numberOfLines={2} style={{ color: labelColor, fontSize: 12, fontStyle: "italic" }}>
                             {labelText}
                         </Text>
@@ -506,7 +548,7 @@ function VtxoRow({ vtxo, selected, onPress, onRefreshIcon, onCancelIcon, isCance
                         </View>
                     )}
                 </View>
-                {vtxo.daysLeft <= 0 ? (
+                {isExpired ? (
                     // Expired action area: no refresh icon, no checkbox —
                     // neither operation is reachable on a VTXO that's past
                     // its expiry height (ASP can sweep it at any time, and
@@ -514,7 +556,7 @@ function VtxoRow({ vtxo, selected, onPress, onRefreshIcon, onCancelIcon, isCance
                     // The badge expands to the combined width of the icon
                     // + select columns (flex 2). Dust-vs-non-dust changes
                     // only the label text — visual treatment is identical.
-                    // Outer row tap is also disabled below for both.
+                    // Outer row tap opens the expiry explainer for both.
                     <View
                         style={{
                             flex: 2,
@@ -961,15 +1003,15 @@ export default function ArkCapsules({ matchedRate, currency }: ArkCapsulesProps)
                 recoverability,
             };
         });
-        // Sort: expired-dust capsules to the bottom of the list. They're
-        // functionally logs — past expiry, below the dust limit, no
-        // refresh path, no economic exit path. Above-the-fold prominence
-        // is wasted on them; users should see live capsules first and
-        // scroll past the carcasses. Everything else preserves the
-        // SDK's natural order.
+        // Sort: expired capsules (dust or not) to the bottom of the list.
+        // They're functionally logs — past expiry, no refresh path, no
+        // send path, no exit path. Above-the-fold prominence is wasted
+        // on them; users should see live capsules first and scroll past
+        // the carcasses. Everything else preserves the SDK's natural
+        // order.
         return mapped.sort((a, b) => {
-            const aDead = a.sats <= ARK_VTXO_DUST_SATS && a.daysLeft <= 0;
-            const bDead = b.sats <= ARK_VTXO_DUST_SATS && b.daysLeft <= 0;
+            const aDead = isExpiredCapsule(a);
+            const bDead = isExpiredCapsule(b);
             if (aDead !== bDead) return aDead ? 1 : -1;
             return 0;
         });
@@ -1141,6 +1183,21 @@ export default function ArkCapsules({ matchedRate, currency }: ArkCapsulesProps)
                 SimpleToast.show(detail, SimpleToast.LONG);
                 return;
             }
+        }
+
+        // Expired capsules can't ride in a round (the ASP rejects expired
+        // inputs and the attempt would wedge). The row UI blocks selecting
+        // them, but a capsule can flip to expired between selection and
+        // tap, so gate here too.
+        const expiredSelected = rows.filter(
+            (r) => ids.includes(r.id) && isExpiredCapsule(r),
+        );
+        if (expiredSelected.length > 0) {
+            SimpleToast.show(
+                `${expiredSelected.length} capsule(s) already expired and can no longer be refreshed`,
+                SimpleToast.LONG,
+            );
+            return;
         }
 
         // Refusing to refresh a VTXO that's already Locked in a pending
@@ -1729,8 +1786,11 @@ export default function ArkCapsules({ matchedRate, currency }: ArkCapsulesProps)
                 shortfall: 0,
             };
         }
+        // Fillers must be LIVE too — an expired non-dust capsule in the
+        // input set would poison the whole consolidation round the same
+        // way expired dust would.
         const nonDust = rows
-            .filter((r) => r.sats > ARK_VTXO_DUST_SATS && !r.pendingRound)
+            .filter((r) => r.sats > ARK_VTXO_DUST_SATS && !r.pendingRound && r.daysLeft > 0)
             .sort((a, b) => a.sats - b.sats);
         const fillers: typeof rows = [];
         let total = dustTotal;

--- a/src/services/ark/refresh.ts
+++ b/src/services/ark/refresh.ts
@@ -2,6 +2,7 @@ import { getArkWalletHandle } from './walletHandle';
 import { fetchArkBalance } from './balance';
 import { fetchArkVtxos } from './vtxos';
 import { recordEvent } from '@Cypher/stores/eventLogStore';
+import useAuthStore from '@Cypher/stores/authStore';
 import type { FeeEstimate, RoundState } from '@secondts/bark-react-native';
 
 export type ArkRefreshFeeView = {
@@ -128,6 +129,9 @@ export async function refreshArkVtxos(
             result: 'success',
             durationMs: Date.now() - t0,
         });
+        // Any successful round breaks the failure streak that drives the
+        // refresh-failing-near-expiry escalation in useArkSync.
+        useAuthStore.getState().setArkRefreshFailStreak(0);
         return { roundId: roundId ?? null };
     } catch (err: any) {
         // BarkError variants carry detail in `err.inner.errorMessage` rather than
@@ -145,6 +149,14 @@ export async function refreshArkVtxos(
             result: 'failure',
             durationMs: Date.now() - t0,
         });
+        // Count consecutive failed submissions across every refresh path
+        // (Capsules tab, notification tap, background sweep all land
+        // here). The pre-submission ArkRefreshInFlightError guard above
+        // doesn't reach this catch, so "already running" rejections
+        // don't inflate the streak. useArkSync escalates once the streak
+        // crosses its threshold while a VTXO is near expiry.
+        const store = useAuthStore.getState();
+        store.setArkRefreshFailStreak(store.arkRefreshFailStreak + 1);
         throw err;
     } finally {
         refreshSubmissionInFlight = false;

--- a/src/stores/authStore.ts
+++ b/src/stores/authStore.ts
@@ -248,6 +248,25 @@ export type AuthStateType = {
     } | null;
     /** Counts only `error` outcomes. Resets to 0 on success. Drives the "couldn't auto-refresh" notification at 2. */
     arkBgRefreshConsecutiveFailures: number;
+    /**
+     * Consecutive FAILED refresh-round submissions across EVERY path
+     * (Capsules tab, notification tap, background sweep) — maintained by
+     * refreshArkVtxos() in services/ark/refresh.ts: a submission that
+     * reaches the SDK and throws increments it, a success resets it to 0.
+     * Distinct from arkBgRefreshConsecutiveFailures, which counts only
+     * background-orchestrator outcomes. Persisted because the failure
+     * streaks that lose funds span days and app restarts (support case
+     * 2026-07-11: 12+ failed refreshes over 3 days against a <2-day
+     * expiry clock, no escalation). Drives the refresh-failing-near-
+     * expiry Alert in useArkSync.
+     */
+    arkRefreshFailStreak: number;
+    /**
+     * Epoch ms when the refresh-failing-near-expiry Alert was last shown.
+     * Gates re-showing so the escalation fires once per re-show window
+     * instead of on every sync tick while the streak persists.
+     */
+    arkRefreshFailAlertAt: number | null;
     /** Set when a post-refresh cloud-backup upload deferred (Phase 4). Surfaces a banner on next foreground. */
     arkBgRefreshDeferredBackup: boolean;
     /** Last fire time of the <24h-to-expiry notification. Used to suppress repeat fires within a 12h window. */
@@ -348,6 +367,8 @@ export type AuthStateType = {
         } | null,
     ) => void;
     setArkBgRefreshConsecutiveFailures: (state: number) => void;
+    setArkRefreshFailStreak: (state: number) => void;
+    setArkRefreshFailAlertAt: (state: number | null) => void;
     setArkBgRefreshDeferredBackup: (state: boolean) => void;
     setArkBgRefreshLastWarn24hAt: (state: number | null) => void;
     setArkBgRefreshLastWarn2hAt: (state: number | null) => void;
@@ -427,6 +448,8 @@ const createAuthStore = (
     arkBgRefreshLastSuccessAt: null,
     arkBgRefreshLastAttempt: null,
     arkBgRefreshConsecutiveFailures: 0,
+    arkRefreshFailStreak: 0,
+    arkRefreshFailAlertAt: null,
     arkBgRefreshDeferredBackup: false,
     arkBgRefreshLastWarn24hAt: null,
     arkBgRefreshLastWarn2hAt: null,
@@ -489,6 +512,8 @@ const createAuthStore = (
     setArkBgRefreshLastSuccessAt: (state: number | null) => set({ arkBgRefreshLastSuccessAt: state }),
     setArkBgRefreshLastAttempt: (state) => set({ arkBgRefreshLastAttempt: state }),
     setArkBgRefreshConsecutiveFailures: (state: number) => set({ arkBgRefreshConsecutiveFailures: state }),
+    setArkRefreshFailStreak: (state: number) => set({ arkRefreshFailStreak: state }),
+    setArkRefreshFailAlertAt: (state: number | null) => set({ arkRefreshFailAlertAt: state }),
     setArkBgRefreshDeferredBackup: (state: boolean) => set({ arkBgRefreshDeferredBackup: state }),
     setArkBgRefreshLastWarn24hAt: (state: number | null) => set({ arkBgRefreshLastWarn24hAt: state }),
     setArkBgRefreshLastWarn2hAt: (state: number | null) => set({ arkBgRefreshLastWarn2hAt: state }),
@@ -529,6 +554,8 @@ const createAuthStore = (
             arkBgRefreshLastSuccessAt: null,
             arkBgRefreshLastAttempt: null,
             arkBgRefreshConsecutiveFailures: 0,
+            arkRefreshFailStreak: 0,
+            arkRefreshFailAlertAt: null,
             arkBgRefreshDeferredBackup: false,
             arkBgRefreshLastWarn24hAt: null,
             arkBgRefreshLastWarn2hAt: null,


### PR DESCRIPTION
Expired VTXOs used to be filtered out of the capsule list entirely, so a wallet whose only capsule expired read as an unexplained zero balance (support case 2026-07-11). They now stay in the store and render on the Capsules tab as greyed non-actionable Expired rows with an explainer; the headline balance still excludes their sats. Consumers that act on VTXOs (dust consolidation fillers, manual refresh, home-card expiry nudges) now skip past-expiry entries explicitly.

Refresh failures also never escalated: 12+ failed rounds against a <2-day expiry clock stayed silent. A persisted streak counter now tracks consecutive failed round submissions across every refresh path; at 3 failures with any spendable VTXO inside the 2-day urgency window, a blocking alert recommends switching networks and retrying, then Settings > Emergency Exit before expiry. Re-shown at most every 6h.