### PR TITLE
fix(recovery): lift the 12-word seed grids clear of the keyboard

### DIFF
--- a/src/custom-hooks/index.ts
+++ b/src/custom-hooks/index.ts
@@ -6,4 +6,5 @@ export type {ArkRestoreBootStatus} from './useArkRestoreOnBoot';
 export {default as useArkExitDestinationBackfill} from './useArkExitDestinationBackfill';
 export {default as useArkoorReceivePrompt} from './useArkoorReceivePrompt';
 export {default as useEasedProgress} from './useEasedProgress';
+export {default as useKeyboardLift} from './useKeyboardLift';
 export {CarouselPageVisibilityContext} from './carouselPageVisibility';

--- a/src/custom-hooks/useKeyboardLift.ts
+++ b/src/custom-hooks/useKeyboardLift.ts
@@ -1,0 +1,42 @@
+import { useEffect, useRef } from 'react';
+import { Animated, Keyboard, KeyboardEvent, Platform } from 'react-native';
+
+/**
+ * Animated translateY that lifts content out of the keyboard's way.
+ *
+ * Built for the 12-word seed grids (Hot Vault + Bark recovery): the keyboard
+ * covers words 11/12, so the grid shifts up by `liftPt` while the user types
+ * and settles back when the keyboard hides. Sliding up under the screen
+ * header is deliberate — keeping every word visible beats keeping the title.
+ *
+ * iOS rides `keyboardWillShow/Hide` with the event's own duration so the
+ * grid moves in sync with the keyboard slide; Android only emits the
+ * `Did` events, so it animates with a short fixed duration instead.
+ *
+ * Usage:
+ *   const keyboardLift = useKeyboardLift(40);
+ *   <Animated.View style={{ transform: [{ translateY: keyboardLift }] }}>
+ */
+export default function useKeyboardLift(liftPt: number): Animated.Value {
+    const lift = useRef(new Animated.Value(0)).current;
+
+    useEffect(() => {
+        const showEvt = Platform.OS === 'ios' ? 'keyboardWillShow' : 'keyboardDidShow';
+        const hideEvt = Platform.OS === 'ios' ? 'keyboardWillHide' : 'keyboardDidHide';
+        const animateTo = (toValue: number) => (e: KeyboardEvent) => {
+            Animated.timing(lift, {
+                toValue,
+                duration: e?.duration && e.duration > 0 ? e.duration : 220,
+                useNativeDriver: true,
+            }).start();
+        };
+        const show = Keyboard.addListener(showEvt, animateTo(-liftPt));
+        const hide = Keyboard.addListener(hideEvt, animateTo(0));
+        return () => {
+            show.remove();
+            hide.remove();
+        };
+    }, [lift, liftPt]);
+
+    return lift;
+}

--- a/src/screens/Account/RecoverArkScreen/index.tsx
+++ b/src/screens/Account/RecoverArkScreen/index.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef, useState } from "react";
-import { ActivityIndicator, Alert, Platform, TouchableOpacity, View } from "react-native";
+import { ActivityIndicator, Alert, Animated, Platform, TouchableOpacity, View } from "react-native";
 import DocumentPicker, { types as DocTypes } from "react-native-document-picker";
 import RNFS from "react-native-fs";
 import * as Keychain from "react-native-keychain";
@@ -25,6 +25,7 @@ import {
 import type { ChannelLookupResult } from "@Cypher/services/ark";
 import { validateMnemonic } from "@secondts/bark-react-native";
 import useAuthStore from "@Cypher/stores/authStore";
+import { useKeyboardLift } from "@Cypher/custom-hooks";
 import { colors } from "@Cypher/style-guide";
 
 import styles from "./styles";
@@ -960,8 +961,11 @@ function TypeSeedView({
     onRestoreCloud,
     onBack,
 }: TypeSeedViewProps) {
+    // Lift the view when the keyboard shows so words 11/12 stay visible
+    // while typing (slides up under the header, same as RecoverSavingVault).
+    const keyboardLift = useKeyboardLift(40);
     return (
-        <>
+        <Animated.View style={{ transform: [{ translateY: keyboardLift }] }}>
             <Text bold style={styles.introTitle}>
                 Type your 12-word Ark seed phrase
             </Text>
@@ -1065,6 +1069,6 @@ function TypeSeedView({
                     <Text style={{ color: colors.gray.light, fontSize: 12 }}>{`← Back to ${BIOMETRIC_LABEL} unlock`}</Text>
                 </TouchableOpacity>
             )}
-        </>
+        </Animated.View>
     );
 }

--- a/src/screens/RecoverSavingVault/index.tsx
+++ b/src/screens/RecoverSavingVault/index.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useContext, useEffect, useRef } from 'react';
-import { Alert, ActivityIndicator, TouchableOpacity, View } from 'react-native';
+import { Alert, ActivityIndicator, Animated, TouchableOpacity, View } from 'react-native';
 import styles from './styles';
 import { ScreenLayout, Text, Input, Button } from '@Cypher/component-library';
 import { colors } from '@Cypher/style-guide';
@@ -7,6 +7,7 @@ import { HDSegwitBech32Wallet } from '../../../class';
 import triggerHapticFeedback, { HapticFeedbackTypes } from '../../../blue_modules/hapticFeedback';
 import { BlueStorageContext } from '../../../blue_modules/storage-context';
 import useAuthStore from "@Cypher/stores/authStore";
+import { useKeyboardLift } from '@Cypher/custom-hooks';
 import { dispatchReset } from '@Cypher/helpers/navigation';
 import {
     getHotVaultSeedFromKeychain,
@@ -40,6 +41,9 @@ export default function RecoverSavingVault({ route }: Props) {
     const autoAttempted = useRef(false);
     const importing = useRef(false);
     const inputRefs = useRef<Array<any>>(new Array(inputs.length));
+    // Lift the whole content block when the keyboard shows so words 11/12
+    // stay visible while typing (the grid slides up under the header).
+    const keyboardLift = useKeyboardLift(40);
 
     // Auto-recover from Keychain on mount — mimics password-autofill UX.
     //
@@ -462,7 +466,7 @@ export default function RecoverSavingVault({ route }: Props) {
 
     return (
         <ScreenLayout title="Enter Your Seed phrase" showToolbar isBackButton disableScroll>
-            <View style={styles.container}>
+            <Animated.View style={[styles.container, { transform: [{ translateY: keyboardLift }] }]}>
                 {loading ?
                     <ActivityIndicator style={{ marginTop: 10, marginBottom: 20 }} color={colors.white} />
                     :
@@ -525,7 +529,7 @@ export default function RecoverSavingVault({ route }: Props) {
                         />
                     </>
                 }
-            </View>
+            </Animated.View>
         </ScreenLayout>
     );
 }


### PR DESCRIPTION
The keyboard covered words 11-12 on both seed-entry screens (Hot Vault + Bark recovery). Shared useKeyboardLift hook shifts the grid up 40pt in sync with the keyboard slide and settles it back on dismiss. Device-verified on the A14.