### PR TITLE
chore(release): Android versionCode 28

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -99,7 +99,7 @@ android {
         applicationId "io.cypherbox.btc"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 27
+        versionCode 28
         versionName "0.1.3"
         testBuildType System.getProperty('testBuildType', 'debug')
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'


### PR DESCRIPTION
versionCode 27 was already consumed on Play (a prior upload attempt registered it), so Play rejects it. Bump to 28. versionName stays 0.1.3; iOS unaffected. Requires an Android rebuild+re-sign from the new tag.