### PR TITLE
Promote vc29 to CB-Production (fix fiat Ark invoice amount)

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -99,7 +99,7 @@ android {
         applicationId "io.cypherbox.btc"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 28
+        versionCode 29
         versionName "0.1.3"
         testBuildType System.getProperty('testBuildType', 'debug')
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'

--- a/ios/BlueWallet/Info.plist
+++ b/ios/BlueWallet/Info.plist
@@ -119,7 +119,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>13</string>
+	<string>14</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSApplicationCategoryType</key>

--- a/src/screens/Ark/ArkInvoiceScreen/index.tsx
+++ b/src/screens/Ark/ArkInvoiceScreen/index.tsx
@@ -41,16 +41,18 @@ export default function ArkInvoiceScreen({ navigation, route }: any) {
             SimpleToast.show("Please enter an amount", SimpleToast.SHORT);
             return;
         }
-        // Resolve the sat amount from whichever mode the keyboard last wrote
-        // to. Both `sats` and `usd` are kept in sync by CustomKeyboard's
-        // onchange, but we defend against a torn state by recomputing from
-        // `usd` when the user submitted in USD mode. Integer-rounded so the
-        // SDK doesn't reject a fractional sat.
+        // Resolve the sat amount. CustomKeyboard writes the raw typed value to
+        // `sats` and the converted counterpart to `usd`, so in fiat mode `usd`
+        // ALREADY holds the sat amount (and `sats` holds the dollars) — the same
+        // contract the CoinOS CreateInvoice sibling reads as
+        // `isSats ? Number(sats) : Number(usd)`. The old code re-divided that
+        // already-in-sats `usd` value by the rate and multiplied by 1e8 again,
+        // double-converting: a $100 fiat entry asked the ASP for ~1.1 BTC
+        // (~1000x too much), which it can't invoice — the "Failed to create Ark
+        // invoice" the user hit. Round because the fiat-mode value carries 2
+        // decimals from the keyboard's toFixed.
         const rate = Number(matchedRate) || 0;
-        let satsAmount = Number(sats);
-        if (!isSats && rate > 0 && usd) {
-            satsAmount = Math.round((Number(usd) / rate) * 100000000);
-        }
+        const satsAmount = Math.round(isSats ? Number(sats) : Number(usd));
         if (!Number.isFinite(satsAmount) || satsAmount <= 0) {
             SimpleToast.show("Please enter a valid amount", SimpleToast.SHORT);
             return;

--- a/src/screens/CopyInvoice/index.tsx
+++ b/src/screens/CopyInvoice/index.tsx
@@ -64,7 +64,7 @@ export default function CopyInvoice({ route }: Props) {
         <ScreenLayout showToolbar title='Copy Invoice'>
             <View style={styles.container}>
                 <View style={styles.innerView}>
-                    <Text bold h1>{route?.params?.value}</Text>
+                    <Text bold h1 adjustsFontSizeToFit numberOfLines={1}>{route?.params?.value}</Text>
                     <Text bold style={styles.usd}>{route?.params?.converted}</Text>
                     {/* <Image source={QrCode} resizeMode="contain" style={styles.image} /> */}
                     <View style={{ margin: 20, padding: 30, backgroundColor: 'white', borderRadius: 30 }}>


### PR DESCRIPTION
Promotes the vc29 bug-fix build to CB-Production (follows #133).

**Fixes**
- fix(ark): fiat-mode Ark Lightning invoices double-converted the amount. A dollar entry requested roughly 1000x the intended sats (a $100 entry asked the ASP for about 1.1 BTC), which it cannot invoice, showing as "Failed to create Ark invoice". The screen now reads the keyboard's already-converted sat value directly, matching the CreateInvoice sibling. Verified on device with $100.
- Invoice amount now shrinks to a single line on the shared invoice and QR screen so large sat counts no longer wrap.

**Release**
- chore(release): iOS CFBundleVersion 13 to 14, Android versionCode 28 to 29 (versionName stays 0.1.3).
