### PR TITLE
fix(home): USD symbol on Bark/CoinOS cards + drop Strike from total on logout

### DIFF
--- a/src/screens/HomeScreen/WalletsView/index.tsx
+++ b/src/screens/HomeScreen/WalletsView/index.tsx
@@ -477,7 +477,10 @@ const WalletsView = forwardRef<WalletsViewHandle, Props>(function WalletsView({
         hasArkWallet;
 
     const walletTabsMap = {
-        COINOS: { key: 'coinos', component: () => <CoinosWallet balance={balance} convertedRate={convertedRate} currency={currency} isLoading={isLoading} matchedRate={matchedRate} refRBSheet={refRBSheet} refSendRBSheet={refSendRBSheet} setReceiveType={setReceiveType} wallet={wallet} homeMessage={homeMessage} hideActionButtons={useSharedButtons}/> },
+        // CoinOS is USD-denominated (convertedRate is the USD figure), so its
+        // symbol is always "$", not the Strike account currency — same fix as
+        // the Bark card below.
+        COINOS: { key: 'coinos', component: () => <CoinosWallet balance={balance} convertedRate={convertedRate} currency="USD" isLoading={isLoading} matchedRate={matchedRate} refRBSheet={refRBSheet} refSendRBSheet={refSendRBSheet} setReceiveType={setReceiveType} wallet={wallet} homeMessage={homeMessage} hideActionButtons={useSharedButtons}/> },
         STRIKE: { key: 'strike', component: () => <StrikeWallet currency={currencyStrike} isLoading={isLoading} matchedRateStrike={matchedRateStrike} strikeConvertedBalance={strikeConvertedBalance} refRBSheet={refRBSheet} refSendRBSheet={refSendRBSheet} setReceiveType={setReceiveType} strikeBalance={strikeBalance} homeMessage={homeMessage} hideActionButtons={useSharedButtons}/> },
         // Ark-only users (no Lightning) keep the in-card Receive/Send pair
         // because `useSharedButtons` is false in that case. When Lightning
@@ -494,7 +497,12 @@ const WalletsView = forwardRef<WalletsViewHandle, Props>(function WalletsView({
                 <View style={{ marginTop: arkCardExtraOffsetPt }}>
                     <ArkWallet
                         convertedRate={convertedRate}
-                        currency={currency}
+                        // Bark is USD-denominated (arkConvertedRate uses the USD
+                        // oracle), so its symbol is always "$", never the Strike
+                        // account currency — passing `currency` here showed a EUR
+                        // symbol on a USD number for European Strike accounts, and
+                        // kept it after Strike logout until relaunch.
+                        currency="USD"
                         isLoading={isLoading}
                         matchedRate={matchedRate}
                         refRBSheet={refRBSheet}

--- a/src/screens/HomeScreen/index.tsx
+++ b/src/screens/HomeScreen/index.tsx
@@ -1107,8 +1107,8 @@ export default function HomeScreen({ route }: Props) {
                   // orphaned `arkBalance` state from a previous wallet
                   // doesn't pollute the headline before the boot-restore
                   // hook clears it.
-                  balance={`${((btc(1) * (Number(balance) || 0)) + Number(strikeUser?.[0]?.available || 0) + (Number(ColdStorageBalanceVault?.split(' ')[0]) || 0) + (Number(balanceVault?.split(' ')[0]) || 0) + (isArkAuth ? (Number(arkBalance) || 0) * btc(1) : 0)).toFixed(8)} BTC`}
-                  convertedRate={`$${((strikeConvertedBalance || 0) + Number(convertedRate || 0) + ((Number(coldStorageBalanceWithoutSuffix || 0) * Number(matchedRateBTC || 0)) + (Number(balanceWithoutSuffix || 0) * Number(matchedRateBTC || 0))) + (isArkAuth ? (Number(arkBalance) || 0) * Number(matchedRate || 0) * btc(1) : 0)).toFixed(2)}`}
+                  balance={`${((btc(1) * (Number(balance) || 0)) + (isStrikeAuth ? Number(strikeUser?.[0]?.available || 0) : 0) + (Number(ColdStorageBalanceVault?.split(' ')[0]) || 0) + (Number(balanceVault?.split(' ')[0]) || 0) + (isArkAuth ? (Number(arkBalance) || 0) * btc(1) : 0)).toFixed(8)} BTC`}
+                  convertedRate={`$${((isStrikeAuth ? (strikeConvertedBalance || 0) : 0) + Number(convertedRate || 0) + ((Number(coldStorageBalanceWithoutSuffix || 0) * Number(matchedRateBTC || 0)) + (Number(balanceWithoutSuffix || 0) * Number(matchedRateBTC || 0))) + (isArkAuth ? (Number(arkBalance) || 0) * Number(matchedRate || 0) * btc(1) : 0)).toFixed(2)}`}
                   // Show "+ Add Account" until the user has all three
                   // distinct rails connected. The previous `length < 2`
                   // gate hid the button as soon as any two were added,


### PR DESCRIPTION
Fixes two display bugs that appear when a European Strike account is connected (`strikeCurrency = EUR`).

**Symbol (Bug A + the "€ after logout" half of Bug B)**
The Bark and CoinOS cards are USD-denominated (their converted figures use the USD oracle), but `WalletsView` handed them the Strike account currency. `Card` renders the symbol from that currency, so a USD number showed a `€` symbol, and it persisted after Strike logout until an app relaunch (the symbol was chained to `strikeCurrency`, which does not reset promptly). Fix: pass `currency="USD"` to both cards. `StrikeWallet` keeps its own `currencyStrike`.

**Total balance (the other half of Bug B)**
The headline total gates the Ark term on `isArkAuth` but left the Strike terms (`strikeUser` available + `strikeConvertedBalance`) ungated, so the Strike balance kept counting toward the total after logout until relaunch. Fix: gate both Strike terms on `isStrikeAuth`, matching the Ark pattern.

**Verify on device:** with a European Strike account, the Bark and CoinOS cards show `$` on the USD number; after logging out of Strike, the total drops the Strike balance immediately, no relaunch needed.
