### PR TITLE
Release vc30 — 0.1.3 / iOS build 15 / Android vc30 (device-QA fixes)

### DIFF
--- a/App.js
+++ b/App.js
@@ -13,7 +13,7 @@ import {
   LogBox,
 } from 'react-native';
 import { NavigationContainer, CommonActions } from '@react-navigation/native';
-import { SafeAreaProvider } from 'react-native-safe-area-context';
+import { SafeAreaProvider, initialWindowMetrics } from 'react-native-safe-area-context';
 import { navigationRef } from './NavigationService';
 import * as NavigationService from './NavigationService';
 import { Chain } from './models/bitcoinUnits';
@@ -257,8 +257,12 @@ const App = () => {
     }
   }, []);
 
+  // initialMetrics gives the provider synchronous safe-area insets on the very
+  // first frame. Without it, insets resolve a frame or two late, so screens
+  // render flush to the top and then visibly drop down once the top inset
+  // applies (the "lifted then settles" jump on navigation).
   return (
-    <SafeAreaProvider>
+    <SafeAreaProvider initialMetrics={initialWindowMetrics}>
       <View style={styles.root}>
         <NavigationContainer ref={navigationRef} theme={colorScheme === 'dark' ? BlueDarkTheme : BlueDefaultTheme}>
           <InitRoot />

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -99,7 +99,7 @@ android {
         applicationId "io.cypherbox.btc"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 29
+        versionCode 30
         versionName "0.1.3"
         testBuildType System.getProperty('testBuildType', 'debug')
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'

--- a/ios/BlueWallet/Info.plist
+++ b/ios/BlueWallet/Info.plist
@@ -119,7 +119,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>14</string>
+	<string>15</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSApplicationCategoryType</key>

--- a/src/screens/Ark/ArkSendScreen/index.tsx
+++ b/src/screens/Ark/ArkSendScreen/index.tsx
@@ -2,6 +2,7 @@ import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import bolt11 from 'bolt11';
 import {
     Clipboard,
+    Keyboard,
     ScrollView,
     TextInput,
     TouchableOpacity,
@@ -274,6 +275,13 @@ export default function ArkSendScreen({ route }: Props) {
                         autoCorrect={false}
                         spellCheck={false}
                         multiline
+                        // A destination is a single line, so the return key
+                        // should dismiss the keyboard rather than insert a
+                        // newline. `blurOnSubmit` overrides the multiline default
+                        // (which keeps the keyboard up until you tap outside).
+                        returnKeyType="done"
+                        blurOnSubmit={true}
+                        onSubmitEditing={() => Keyboard.dismiss()}
                     />
                     <TouchableOpacity style={styles.pasteBtn} onPress={handlePaste}>
                         <Text style={styles.pasteBtnText}>PASTE</Text>

--- a/src/screens/HomeScreen/WalletsView/index.tsx
+++ b/src/screens/HomeScreen/WalletsView/index.tsx
@@ -477,7 +477,10 @@ const WalletsView = forwardRef<WalletsViewHandle, Props>(function WalletsView({
         hasArkWallet;
 
     const walletTabsMap = {
-        COINOS: { key: 'coinos', component: () => <CoinosWallet balance={balance} convertedRate={convertedRate} currency={currency} isLoading={isLoading} matchedRate={matchedRate} refRBSheet={refRBSheet} refSendRBSheet={refSendRBSheet} setReceiveType={setReceiveType} wallet={wallet} homeMessage={homeMessage} hideActionButtons={useSharedButtons}/> },
+        // CoinOS is USD-denominated (convertedRate is the USD figure), so its
+        // symbol is always "$", not the Strike account currency — same fix as
+        // the Bark card below.
+        COINOS: { key: 'coinos', component: () => <CoinosWallet balance={balance} convertedRate={convertedRate} currency="USD" isLoading={isLoading} matchedRate={matchedRate} refRBSheet={refRBSheet} refSendRBSheet={refSendRBSheet} setReceiveType={setReceiveType} wallet={wallet} homeMessage={homeMessage} hideActionButtons={useSharedButtons}/> },
         STRIKE: { key: 'strike', component: () => <StrikeWallet currency={currencyStrike} isLoading={isLoading} matchedRateStrike={matchedRateStrike} strikeConvertedBalance={strikeConvertedBalance} refRBSheet={refRBSheet} refSendRBSheet={refSendRBSheet} setReceiveType={setReceiveType} strikeBalance={strikeBalance} homeMessage={homeMessage} hideActionButtons={useSharedButtons}/> },
         // Ark-only users (no Lightning) keep the in-card Receive/Send pair
         // because `useSharedButtons` is false in that case. When Lightning
@@ -494,7 +497,12 @@ const WalletsView = forwardRef<WalletsViewHandle, Props>(function WalletsView({
                 <View style={{ marginTop: arkCardExtraOffsetPt }}>
                     <ArkWallet
                         convertedRate={convertedRate}
-                        currency={currency}
+                        // Bark is USD-denominated (arkConvertedRate uses the USD
+                        // oracle), so its symbol is always "$", never the Strike
+                        // account currency — passing `currency` here showed a EUR
+                        // symbol on a USD number for European Strike accounts, and
+                        // kept it after Strike logout until relaunch.
+                        currency="USD"
                         isLoading={isLoading}
                         matchedRate={matchedRate}
                         refRBSheet={refRBSheet}

--- a/src/screens/HomeScreen/index.tsx
+++ b/src/screens/HomeScreen/index.tsx
@@ -1107,8 +1107,8 @@ export default function HomeScreen({ route }: Props) {
                   // orphaned `arkBalance` state from a previous wallet
                   // doesn't pollute the headline before the boot-restore
                   // hook clears it.
-                  balance={`${((btc(1) * (Number(balance) || 0)) + Number(strikeUser?.[0]?.available || 0) + (Number(ColdStorageBalanceVault?.split(' ')[0]) || 0) + (Number(balanceVault?.split(' ')[0]) || 0) + (isArkAuth ? (Number(arkBalance) || 0) * btc(1) : 0)).toFixed(8)} BTC`}
-                  convertedRate={`$${((strikeConvertedBalance || 0) + Number(convertedRate || 0) + ((Number(coldStorageBalanceWithoutSuffix || 0) * Number(matchedRateBTC || 0)) + (Number(balanceWithoutSuffix || 0) * Number(matchedRateBTC || 0))) + (isArkAuth ? (Number(arkBalance) || 0) * Number(matchedRate || 0) * btc(1) : 0)).toFixed(2)}`}
+                  balance={`${((btc(1) * (Number(balance) || 0)) + (isStrikeAuth ? Number(strikeUser?.[0]?.available || 0) : 0) + (Number(ColdStorageBalanceVault?.split(' ')[0]) || 0) + (Number(balanceVault?.split(' ')[0]) || 0) + (isArkAuth ? (Number(arkBalance) || 0) * btc(1) : 0)).toFixed(8)} BTC`}
+                  convertedRate={`$${((isStrikeAuth ? (strikeConvertedBalance || 0) : 0) + Number(convertedRate || 0) + ((Number(coldStorageBalanceWithoutSuffix || 0) * Number(matchedRateBTC || 0)) + (Number(balanceWithoutSuffix || 0) * Number(matchedRateBTC || 0))) + (isArkAuth ? (Number(arkBalance) || 0) * Number(matchedRate || 0) * btc(1) : 0)).toFixed(2)}`}
                   // Show "+ Add Account" until the user has all three
                   // distinct rails connected. The previous `length < 2`
                   // gate hid the button as soon as any two were added,

--- a/src/screens/Strike/CheckingAccountNew/Settings.tsx
+++ b/src/screens/Strike/CheckingAccountNew/Settings.tsx
@@ -71,6 +71,15 @@ export default function Settings({ receiveType, currency, isArk }: Props) {
   const [bankMethods, setBankMethods] = useState<any[]>([]);
 
   useEffect(() => {
+    // The Bark vault reuses this Settings screen but renders none of the Strike
+    // data (no profile, fiat limits, or bank methods — see the `isArk` branch
+    // below), so skip the Strike fetches entirely. Otherwise the vault fires
+    // getStrikeProfile / getStrikeLimits / getBankPaymentMethods on mount, which
+    // error in the background whenever Strike isn't logged in.
+    if (isArk) {
+      setIsLoading(false);
+      return;
+    }
     if (!receiveType) {
       loadStrikeData();
     } else {

--- a/src/services/ark/send.ts
+++ b/src/services/ark/send.ts
@@ -4,6 +4,7 @@ import {
     LightningSendStatus_Tags,
     validateArkAddress,
 } from '@secondts/bark-react-native';
+import bolt11 from 'bolt11';
 
 import { ensureArkWalletHandleReady } from './restore';
 import { fetchArkBalance } from './balance';
@@ -173,10 +174,48 @@ async function waitForArkLightningSettlement(
     opts: { timeoutMs?: number; pollMs?: number } = {},
 ): Promise<'settled' | 'failed' | 'pending'> {
     const timeoutMs = opts.timeoutMs ?? 75_000;
-    const pollMs = opts.pollMs ?? 3_000;
+    // Poll fast: a Lightning payment settles in seconds, and the authoritative
+    // check below reports Paid the moment it does, so keep the send screen
+    // snappy instead of waiting whole seconds between checks.
+    const pollMs = opts.pollMs ?? 1_000;
     const deadline = Date.now() + timeoutMs;
 
+    // Decode the payment hash so we can poll `checkLightningPayment` — the SAME
+    // authoritative settlement signal the background pending-send driver uses
+    // (see driveArkPendingLightningSends). The movement-history string match
+    // below only matches when the invoice string appears in `sentToAddresses`,
+    // which is true for ln-invoice but NOT for ln-address / ln-offer (their
+    // movement records the address/offer, not the resolved bolt11). That made
+    // the wait time out to 'pending' for ln-address sends that had actually
+    // settled — the user saw a "still confirming" failure for a Paid payment.
+    let paymentHash: string | null = null;
+    try {
+        const tag = bolt11.decode(invoice).tags.find((t) => t.tagName === 'payment_hash');
+        paymentHash = typeof tag?.data === 'string' ? tag.data : null;
+    } catch {
+        // `invoice` isn't a decodable bolt11 (e.g. an Unknown-status raw
+        // address/offer) — fall back to the history match below.
+    }
+
     while (Date.now() < deadline) {
+        // 1) Authoritative success: checkLightningPayment reports Paid as soon as
+        //    the ASP confirms settlement, for every destination kind. This is
+        //    what makes ln-address sends resolve correctly and fast. It only
+        //    reports Unknown/InProgress/Paid — never failure — so terminal
+        //    failure is still detected via the movement history below.
+        if (paymentHash) {
+            try {
+                const st = await handle.checkLightningPayment(paymentHash, false);
+                if (st.tag === LightningSendStatus_Tags.Paid) {
+                    if (__DEV__) console.log('[Ark send] settlement confirmed via checkLightningPayment');
+                    return 'settled';
+                }
+            } catch (err) {
+                if (__DEV__) console.warn('[Ark send] checkLightningPayment poll error (continuing):', err);
+            }
+        }
+        // 2) Fallback match + terminal failure: the movement history carries the
+        //    'failed'/'canceled' state that checkLightningPayment cannot report.
         try {
             const movements = await handle.history();
             const m = movements


### PR DESCRIPTION
Release **0.1.3 / iOS build 15 / Android versionCode 30**. This session's device-QA fixes on top of vc29 (iOS build 15 archived and uploaded to TestFlight from this branch).

- **Currency symbol:** the Bark and CoinOS cards show `$` on their USD figure instead of the Strike account's EUR, and the Strike balance drops from the headline total the moment Strike logs out (gated on `isStrikeAuth`), no relaunch needed.
- **Bark vault Settings:** skip the Strike profile/limits/bank-method fetches for the Ark vault (`isArk`), which errored in the background whenever Strike was logged out (leftover from the shared Strike Settings screen).
- **Ark LN send:** confirm settlement via `checkLightningPayment` (poll 1s) so ln-address sends resolve fast instead of false-reporting "still confirming" for a payment that already settled.
- **Bark send destination:** the return/Done key dismisses the keyboard (multiline `blurOnSubmit`).
- **App-wide:** `SafeAreaProvider` gets `initialWindowMetrics`, eliminating the "render flush to the top then drop into place" jump on screen entry.
- `chore(release)`: CFBundleVersion 14→15, Android versionCode 29→30.

Supersedes #137 (its currency-symbol fix is included here). The #136 build-number wiring stays as its own follow-up.
