### PR TITLE
Release v0.1.4 (vc31): emergency-exit fee funding + stuck-refresh swap-out

### DIFF
--- a/Navigation.js
+++ b/Navigation.js
@@ -113,6 +113,7 @@ import ArkSendReviewScreen from '@Cypher/screens/Ark/ArkSendReviewScreen';
 import ArkSendSuccessScreen from '@Cypher/screens/Ark/ArkSendSuccessScreen';
 import ArkWithdrawReviewScreen from '@Cypher/screens/Ark/ArkWithdrawReviewScreen';
 import ArkCapsulesInfoScreen from '@Cypher/screens/Ark/ArkCapsulesInfoScreen';
+import ArkStuckCapsuleScreen from '@Cypher/screens/Ark/ArkStuckCapsuleScreen';
 
 const WalletsStack = createStackNavigator();
 
@@ -212,6 +213,7 @@ const WalletsRoot = () => {
       <WalletsStack.Screen name="ArkReceiveScreen" component={ArkReceiveScreen} options={{ headerShown: false }} />
       <WalletsStack.Screen name="ArkInvoiceScreen" component={ArkInvoiceScreen} options={{ headerShown: false }} />
       <WalletsStack.Screen name="ArkCapsulesInfoScreen" component={ArkCapsulesInfoScreen} options={{ headerShown: false }} />
+      <WalletsStack.Screen name="ArkStuckCapsuleScreen" component={ArkStuckCapsuleScreen} options={{ headerShown: false }} />
       <WalletsStack.Screen name="ArkTransactionDetailsScreen" component={ArkTransactionDetailsScreen} options={{ headerShown: false }} />
       <WalletsStack.Screen name="ArkSendScreen" component={ArkSendScreen} options={{ headerShown: false, gestureEnabled: true }} />
       <WalletsStack.Screen name="ArkSendReviewScreen" component={ArkSendReviewScreen} options={{ headerShown: false, gestureEnabled: true }} />

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -99,8 +99,8 @@ android {
         applicationId "io.cypherbox.btc"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 30
-        versionName "0.1.3"
+        versionCode 31
+        versionName "0.1.4"
         testBuildType System.getProperty('testBuildType', 'debug')
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
         missingDimensionStrategy 'react-native-camera', 'general' //add this line

--- a/ios/BlueWallet.xcodeproj/project.pbxproj
+++ b/ios/BlueWallet.xcodeproj/project.pbxproj
@@ -1196,7 +1196,7 @@
 					"$(SDKROOT)/System/iOSSupport/usr/lib/swift",
 					"$(inherited)",
 				);
-				MARKETING_VERSION = 0.1.3;
+				MARKETING_VERSION = 0.1.4;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",
@@ -1246,7 +1246,7 @@
 					"$(SDKROOT)/System/iOSSupport/usr/lib/swift",
 					"$(inherited)",
 				);
-				MARKETING_VERSION = 0.1.3;
+				MARKETING_VERSION = 0.1.4;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",

--- a/ios/BlueWallet/Info.plist
+++ b/ios/BlueWallet/Info.plist
@@ -119,7 +119,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>15</string>
+	<string>16</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSApplicationCategoryType</key>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cypherbox",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/src/components/ArkWallet/index.tsx
+++ b/src/components/ArkWallet/index.tsx
@@ -629,10 +629,19 @@ export default function ArkWallet({
                                 still-stuck condition pops the banner back. */}
                             {!isLoading && arkRefreshStuck && (
                                 <TouchableOpacity
-                                    onPress={handleStuckRecovery}
+                                    // Near expiry: refreshing is stuck AND the
+                                    // funds are running out, so route to the
+                                    // "move your funds out" screen instead of
+                                    // the in-place cancel-and-retry (which only
+                                    // helps when there's still time to retry).
+                                    onPress={arkRefreshStuck.nearExpiry
+                                        ? () => dispatchNavigate('ArkStuckCapsuleScreen', {})
+                                        : handleStuckRecovery}
                                     activeOpacity={0.7}
                                     accessibilityRole="button"
-                                    accessibilityLabel="Recover stuck refresh"
+                                    accessibilityLabel={arkRefreshStuck.nearExpiry
+                                        ? 'Move your stuck funds out'
+                                        : 'Recover stuck refresh'}
                                 >
                                     <Text
                                         h4
@@ -641,7 +650,9 @@ export default function ArkWallet({
                                             { color: colors.redLight, textDecorationLine: 'underline' },
                                         ]}
                                     >
-                                        Refresh stuck · {arkRefreshStuck.stuckSats.toLocaleString()} sats. Tap to recover
+                                        {arkRefreshStuck.nearExpiry
+                                            ? `Warning: Refresh stuck near expiry · ${arkRefreshStuck.stuckSats.toLocaleString()} sats. Tap to move funds out`
+                                            : `Refresh stuck · ${arkRefreshStuck.stuckSats.toLocaleString()} sats. Tap to recover`}
                                     </Text>
                                 </TouchableOpacity>
                             )}

--- a/src/custom-hooks/useArkSync.ts
+++ b/src/custom-hooks/useArkSync.ts
@@ -4,8 +4,12 @@ import { Alert, AppState, AppStateStatus, InteractionManager, Platform } from 'r
 import {
     applyExpiredVtxoFilter,
     AVG_BLOCK_MINUTES,
+    cancelArkPendingRound,
     cancelVtxoExpiryWarnings,
+    cancelVtxoStuckSwapWarnings,
     claimArkExitsToAddress,
+    getArkCancelling,
+    setArkCancelling,
     fetchArkBalance,
     fetchArkPendingLightningReceives,
     fetchArkPendingRoundStates,
@@ -23,6 +27,7 @@ import {
     resetArkWalletState,
     runBackgroundRefresh,
     scheduleVtxoExpiryWarnings,
+    scheduleVtxoStuckSwapWarnings,
     syncArkExits,
     syncArkWallet,
     tryClaimArkLightningReceives,
@@ -119,6 +124,73 @@ let lastForegroundSweepAt = 0;
 const REFRESH_FAIL_ESCALATE_STREAK = 3;
 const REFRESH_FAIL_ALERT_GAP_MS = 6 * 60 * 60 * 1000;
 
+// --- Stuck-refresh swap-out window + auto-cancel safety net ----------------
+//
+// When a round is detected stuck (useArkSync flags it past 2× the round
+// interval) AND its Locked VTXOs are inside this window of their pre-refresh
+// expiry, the UX escalates from "cancel & retry the refresh" to "move your
+// funds out": swap-out notifications (12h/6h/3h) are scheduled and the
+// in-app banners route to ArkStuckCapsuleScreen. 12h matches the product
+// decision to keep the 24h warning as a normal refresh prompt (a fresh
+// arkoor receive legitimately sits near 24h) and only escalate from 12h.
+const STUCK_SWAP_WINDOW_MS = 12 * 60 * 60 * 1000;
+// Auto-cancel safety net: once a stuck round's Locked funds are inside this
+// window of expiry, cancel the wedged round automatically so the VTXOs unlock
+// with enough runway for the user to still swap / exit before the deadline.
+// Cancelling only unlocks the inputs (per Erik / Bark), it never spends, so
+// this is safe to do without user confirmation. Bam approved this net.
+const STUCK_AUTO_CANCEL_MS = 3 * 60 * 60 * 1000;
+
+// Module-level throttle for the auto-cancel net so a 30s sync tick doesn't
+// hammer cancelPendingRound while a round settles server-side. Mirrors the
+// lastForegroundSweepAt guard above.
+let arkAutoCancelInFlight = false;
+let lastArkAutoCancelAt = 0;
+const ARK_AUTO_CANCEL_MIN_GAP_MS = 5 * 60 * 1000;
+// After an auto-cancel unlocks a stuck round's funds near expiry, keep the
+// urgency sweep off for this long so the funds STAY spendable for the user to
+// swap / exit. Without it, the sweep (which fires within 2 days of expiry)
+// would immediately re-refresh the just-unlocked VTXO and risk re-wedging it
+// against the same misbehaving ASP, the exact loop we're rescuing them from.
+const ARK_POST_AUTOCANCEL_SWEEP_COOLDOWN_MS = 30 * 60 * 1000;
+
+/**
+ * Cancel the given stuck round(s) automatically, then sync so the just-
+ * unlocked VTXOs re-read as Spendable. Guarded + throttled + respects the
+ * shared `cancelling` flag so it never races a user-initiated cancel or the
+ * banner's cancel-and-retry. Per-round failures are swallowed (the round may
+ * already be finalising server-side, in which case the next sync ingests it).
+ */
+async function maybeAutoCancelStuckRounds(roundIds: number[]): Promise<void> {
+    if (!roundIds || roundIds.length === 0) return;
+    if (arkAutoCancelInFlight) return;
+    if (Date.now() - lastArkAutoCancelAt < ARK_AUTO_CANCEL_MIN_GAP_MS) return;
+    // Don't fight a user-initiated cancel (banner cancel-and-retry sets this).
+    if (getArkCancelling()) return;
+    arkAutoCancelInFlight = true;
+    lastArkAutoCancelAt = Date.now();
+    setArkCancelling(true);
+    try {
+        for (const id of roundIds) {
+            try {
+                await cancelArkPendingRound(id);
+            } catch {
+                // cancelArkPendingRound already logs the inner BarkError.
+                // Swallow so one refused round doesn't block the others.
+            }
+        }
+        try {
+            await syncArkWallet();
+        } catch (syncErr: any) {
+            if (__DEV__) console.warn('[Ark auto-cancel] post-cancel sync failed:', syncErr?.message ?? syncErr);
+        }
+        if (__DEV__) console.warn('[Ark auto-cancel] cancelled stuck rounds near expiry:', roundIds);
+    } finally {
+        setArkCancelling(false);
+        arkAutoCancelInFlight = false;
+    }
+}
+
 // --- Self-heal for a failed boot open -------------------------------------
 //
 // useArkRestoreOnBoot runs exactly once per mount and, on a failed open,
@@ -181,6 +253,7 @@ export default function useArkSync(): UseArkSync {
     const setArkRefreshStuck = useAuthStore((s) => s.setArkRefreshStuck);
     const setArkPendingRoundFirstSeen = useAuthStore((s) => s.setArkPendingRoundFirstSeen);
     const setArkScheduledExpiryNotifs = useAuthStore((s) => s.setArkScheduledExpiryNotifs);
+    const setArkScheduledStuckSwapNotifs = useAuthStore((s) => s.setArkScheduledStuckSwapNotifs);
     const setArkPendingLnReceives = useAuthStore((s) => s.setArkPendingLnReceives);
     const setArkChainTipHeight = useAuthStore((s) => s.setArkChainTipHeight);
     const setArkLastSyncedAt = useAuthStore((s) => s.setArkLastSyncedAt);
@@ -672,9 +745,29 @@ export default function useArkSync(): UseArkSync {
                 // expose a vtxo→round link, so this is the total locked across
                 // all rounds, not strictly the stuck-round subset. Fine for a
                 // banner headline since the user cancels all stuck rounds anyway.
-                const lockedSats = (vtxos?.all ?? [])
-                    .filter((v) => v.state.toLowerCase() === 'locked')
-                    .reduce((sum, v) => sum + v.sats, 0);
+                const lockedVtxos = (vtxos?.all ?? []).filter(
+                    (v) => v.state.toLowerCase() === 'locked',
+                );
+                const lockedSats = lockedVtxos.reduce((sum, v) => sum + v.sats, 0);
+                // nearExpiry: is any Locked VTXO inside the swap-out window of
+                // its PRE-refresh expiry? A Locked VTXO's expiryHeight is the
+                // pre-refresh leaf's expiry (the deadline the stuck round
+                // failed to extend), so it IS the real "time left before these
+                // funds are lost" clock (unlike a healthy round, where the
+                // countdown is meaningless; the 2× stuck gate rules that out).
+                // Drives the escalation from "cancel & retry" to "move funds
+                // out" across the notifications + banners.
+                const blockMsStuck = AVG_BLOCK_MINUTES * 60 * 1000;
+                let soonestLockedMsLeft = Infinity;
+                if (typeof tip === 'number') {
+                    for (const v of lockedVtxos) {
+                        if (v.expiryHeight <= 0) continue;
+                        const msLeft = Math.max(0, v.expiryHeight - tip) * blockMsStuck;
+                        if (msLeft < soonestLockedMsLeft) soonestLockedMsLeft = msLeft;
+                    }
+                }
+                const stuckNearExpiry =
+                    isFinite(soonestLockedMsLeft) && soonestLockedMsLeft <= STUCK_SWAP_WINDOW_MS;
                 // Only surface the banner when funds are ACTUALLY locked. Orphan
                 // `finalising` round-state rows linger for days with no locked
                 // inputs (observed live: rounds 8 & 12 flagged with lockedSats=0),
@@ -685,6 +778,7 @@ export default function useArkSync(): UseArkSync {
                         stuckRoundIds: stuck.map((r) => r.id),
                         stuckSats: lockedSats,
                         detectedAtTip: typeof tip === 'number' ? tip : 0,
+                        nearExpiry: stuckNearExpiry,
                     });
                     if (__DEV__) {
                         console.warn(
@@ -696,6 +790,7 @@ export default function useArkSync(): UseArkSync {
                             ),
                             'thresholdSecs=', intervalSecs * 2,
                             'lockedSats=', lockedSats,
+                            'nearExpiry=', stuckNearExpiry,
                         );
                     }
                 } else {
@@ -704,6 +799,73 @@ export default function useArkSync(): UseArkSync {
             } else {
                 // No pending rounds at all → nothing stuck.
                 setArkRefreshStuck(null);
+            }
+
+            // --- Stuck-capsule swap-out notifications + auto-cancel net ---
+            //
+            // When a round is stuck AND its Locked funds are near expiry,
+            // schedule the 12h/6h/3h "move your funds out" alarms (whose tap
+            // routes to ArkStuckCapsuleScreen) and, once inside the 3h
+            // auto-cancel window, cancel the wedged round so the funds unlock
+            // with runway to still swap/exit. Reconciled like the expiry queue:
+            // entries added while stuck+near, cancelled the moment a VTXO stops
+            // qualifying (unlocked / round cleared / no longer near expiry).
+            // Reads arkRefreshStuck fresh (just set above).
+            if (vtxos && typeof tip === 'number') {
+                const stuckNow = useAuthStore.getState().arkRefreshStuck;
+                const prevSwap = useAuthStore.getState().arkScheduledStuckSwapNotifs;
+                const nextSwap: Record<string, number> = {};
+                if (stuckNow && useAuthStore.getState().arkBgRefreshEnabled) {
+                    const blockMs2 = AVG_BLOCK_MINUTES * 60 * 1000;
+                    const nowMs2 = Date.now();
+                    let anyWithinAutoCancel = false;
+                    for (const v of vtxos.all) {
+                        if (v.state.toLowerCase() !== 'locked') continue;
+                        if (v.expiryHeight <= 0) continue;
+                        const expiryAtMs = nowMs2 + Math.max(0, v.expiryHeight - tip) * blockMs2;
+                        const msLeft = expiryAtMs - nowMs2;
+                        if (msLeft <= STUCK_SWAP_WINDOW_MS) {
+                            nextSwap[v.id] = expiryAtMs;
+                            if (prevSwap[v.id] == null) {
+                                try {
+                                    scheduleVtxoStuckSwapWarnings(v.id, expiryAtMs, v.sats);
+                                    if (__DEV__) {
+                                        console.log(
+                                            '[Ark sync] scheduled swap-out warnings for',
+                                            v.id.slice(0, 12),
+                                            'expiry', new Date(expiryAtMs).toISOString(),
+                                        );
+                                    }
+                                } catch (notifErr) {
+                                    console.warn('[Ark sync] scheduleVtxoStuckSwapWarnings threw:', notifErr);
+                                }
+                            }
+                        }
+                        if (msLeft <= STUCK_AUTO_CANCEL_MS) anyWithinAutoCancel = true;
+                    }
+                    // Auto-cancel-at-3h safety net (Bam-approved): unlock the
+                    // wedged round's inputs while there's still time to move out.
+                    if (anyWithinAutoCancel && stuckNow.stuckRoundIds.length > 0) {
+                        void maybeAutoCancelStuckRounds(stuckNow.stuckRoundIds);
+                    }
+                }
+                // Cancel swap-out alarms for VTXOs that no longer qualify
+                // (unlocked, round cleared, or no longer near expiry).
+                for (const id of Object.keys(prevSwap)) {
+                    if (nextSwap[id] == null) {
+                        try {
+                            cancelVtxoStuckSwapWarnings(id);
+                        } catch (notifErr) {
+                            console.warn('[Ark sync] cancelVtxoStuckSwapWarnings threw:', notifErr);
+                        }
+                    }
+                }
+                const prevSwapKeys = Object.keys(prevSwap);
+                const nextSwapKeys = Object.keys(nextSwap);
+                const swapChanged =
+                    prevSwapKeys.length !== nextSwapKeys.length ||
+                    nextSwapKeys.some((k) => prevSwap[k] !== nextSwap[k]);
+                if (swapChanged) setArkScheduledStuckSwapNotifs(nextSwap);
             }
 
             // In-flight LN receives: pay-only entries (hasHtlcVtxos === true)
@@ -828,6 +990,15 @@ export default function useArkSync(): UseArkSync {
             // success rate-limit still applies.
             if (
                 state.arkBgRefreshEnabled &&
+                // Stop feeding the loop: when a round is already wedged, don't
+                // start new rounds on other near-expiry VTXOs. The stuck-swap
+                // flow (banner + notifications + auto-cancel) owns recovery
+                // until the wedge clears, at which point the sweep resumes.
+                !state.arkRefreshStuck &&
+                // And after an auto-cancel unlocks funds near expiry, stay off
+                // for a cooldown so they remain spendable for the user to move
+                // out instead of being immediately re-refreshed into the wedge.
+                Date.now() - lastArkAutoCancelAt > ARK_POST_AUTOCANCEL_SWEEP_COOLDOWN_MS &&
                 isFinite(minBlocks) &&
                 minBlocks < URGENCY_THRESHOLD_BLOCKS &&
                 Date.now() - lastForegroundSweepAt > FOREGROUND_SWEEP_MIN_GAP_MS

--- a/src/screens/Ark/ArkStuckCapsuleScreen/index.tsx
+++ b/src/screens/Ark/ArkStuckCapsuleScreen/index.tsx
@@ -1,0 +1,399 @@
+import React, { useContext, useEffect, useMemo, useState } from "react";
+import { ActivityIndicator, ScrollView, TextInput, TouchableOpacity, View } from "react-native";
+
+import { ScreenLayout, Text } from "@Cypher/component-library";
+import { dispatchNavigate } from "@Cypher/helpers";
+import {
+    AVG_BLOCK_MINUTES,
+    cancelArkPendingRound,
+    estimateArkOffboardFee,
+    fetchArkBalance,
+    fetchArkVtxos,
+    getArkCancelling,
+    offboardArkVtxos,
+    setArkCancelling,
+    syncArkWallet,
+} from "@Cypher/services/ark";
+import { estimateSwapFee, listLightningSwapProviders, swap } from "@Cypher/services/lightningSwap";
+import useAuthStore from "@Cypher/stores/authStore";
+import { colors } from "@Cypher/style-guide";
+import { BlueStorageContext } from "../../../../blue_modules/storage-context";
+
+/**
+ * ArkStuckCapsuleScreen: the "your refresh is stuck, move your funds out" rescue.
+ *
+ * Self-contained, no keyboard, no swap screen. On mount it cancels the wedged
+ * round to UNLOCK the funds (cancelling only unlocks, never spends, per Erik /
+ * Bark), then selects the capsules that are ABOUT TO EXPIRE and moves exactly
+ * those out when the user picks a wallet and taps Exit:
+ *   - Hot / Cold vault / External address: `offboardArkVtxos(expiringIds, addr)`,
+ *     exact coin control on-chain (the offboard fee is taken out of the amount).
+ *   - Strike / Coinos: the Lightning swap engine. bark has no LN coin control,
+ *     but Second confirmed the wallet spends closest-to-expiry VTXOs first, so
+ *     swapping the near-expiry sum spends exactly those. The Ark LN routing fee
+ *     is charged ON TOP, so we swap (sum - fee) to leave headroom.
+ *
+ * The unilateral Emergency Exit is deliberately NOT offered here (it needs ~a
+ * day of runway to unroll before expiry, so it is an early tool, not a
+ * near-expiry rescue). It stays in Settings.
+ */
+
+type Dest = "strike" | "coinos" | "hot" | "cold" | "external";
+
+// "About to expire" window. The feature is reached at 12h; 24h captures the
+// at-risk set with margin. Tunable.
+const ABOUT_TO_EXPIRE_BLOCKS = Math.round((24 * 60) / AVG_BLOCK_MINUTES);
+
+function looksLikeBitcoinAddress(s: string): boolean {
+    const t = s.trim();
+    if (t.length < 14 || t.length > 100) return false;
+    return /^(bc1|tb1|bcrt1|[13]|[mn2])[a-zA-Z0-9]+$/.test(t);
+}
+
+export default function ArkStuckCapsuleScreen() {
+    const arkVtxos = useAuthStore((s) => s.arkVtxos);
+    const tip = useAuthStore((s) => s.arkChainTipHeight);
+    const walletID = useAuthStore((s) => s.walletID);
+    const coldStorageWalletID = useAuthStore((s) => s.coldStorageWalletID);
+    const { wallets } = useContext(BlueStorageContext);
+
+    const [preparing, setPreparing] = useState(true);
+    const [selected, setSelected] = useState<Dest | null>(null);
+    const [externalAddr, setExternalAddr] = useState("");
+    const [feeSats, setFeeSats] = useState<number | null>(null);
+    const [estimating, setEstimating] = useState(false);
+    const [exiting, setExiting] = useState(false);
+    const [result, setResult] = useState<{ ok: boolean; msg: string } | null>(null);
+
+    // Cancel the wedged round on mount to unlock the funds, then reconcile.
+    useEffect(() => {
+        let done = false;
+        (async () => {
+            const stuck = useAuthStore.getState().arkRefreshStuck;
+            if (stuck && stuck.stuckRoundIds.length > 0 && !getArkCancelling()) {
+                setArkCancelling(true);
+                try {
+                    for (const id of stuck.stuckRoundIds) {
+                        try {
+                            await cancelArkPendingRound(id);
+                        } catch {
+                            // cancelArkPendingRound already logs the inner BarkError.
+                        }
+                    }
+                    try {
+                        await syncArkWallet();
+                        await Promise.all([fetchArkBalance(), fetchArkVtxos()]);
+                    } catch {
+                        // Non-fatal; the next sync tick reconciles.
+                    }
+                    useAuthStore.getState().setArkRefreshStuck(null);
+                } finally {
+                    setArkCancelling(false);
+                }
+            }
+            if (!done) setPreparing(false);
+        })();
+        return () => {
+            done = true;
+        };
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
+
+    // Capsules about to expire: spendable, non-arkoor, within the window.
+    const expiring = useMemo(() => {
+        if (tip == null) return { ids: [] as string[], sats: 0 };
+        const ids: string[] = [];
+        let sats = 0;
+        for (const v of arkVtxos) {
+            if (v.state.toLowerCase() !== "spendable") continue;
+            if (v.expiryHeight <= 0) continue; // arkoor (no own expiry)
+            const blocksLeft = v.expiryHeight - tip;
+            if (blocksLeft <= 0) continue; // already expired
+            if (blocksLeft > ABOUT_TO_EXPIRE_BLOCKS) continue;
+            ids.push(v.id);
+            sats += v.sats;
+        }
+        return { ids, sats };
+    }, [arkVtxos, tip]);
+
+    const strikeMe = useAuthStore((s) => s.strikeMe);
+    const coinosUser = useAuthStore((s) => s.user);
+    const swapAvail = useMemo(() => {
+        const providers = listLightningSwapProviders();
+        return {
+            strike: providers.find((p) => p.id === "strike")?.isAvailable() ?? false,
+            coinos: providers.find((p) => p.id === "coinos")?.isAvailable() ?? false,
+        };
+    }, []);
+
+    const resolveVaultAddress = (id?: string): string | null => {
+        if (!id) return null;
+        const w: any = (wallets || []).find((x: any) => x?.getID?.() === id);
+        if (!w) return null;
+        try {
+            const next = w.getNextFreeAddressIndex?.() ?? 0;
+            return w._getExternalAddressByIndex?.(next) || null;
+        } catch {
+            return null;
+        }
+    };
+
+    const addressFor = (dest: Dest): string | null => {
+        if (dest === "hot") return resolveVaultAddress(walletID);
+        if (dest === "cold") return resolveVaultAddress(coldStorageWalletID);
+        if (dest === "external") return looksLikeBitcoinAddress(externalAddr) ? externalAddr.trim() : null;
+        return null;
+    };
+
+    const isOnchain = (dest: Dest) => dest === "hot" || dest === "cold" || dest === "external";
+
+    // Estimate the fee whenever the selection (or external address) changes.
+    useEffect(() => {
+        if (!selected || expiring.ids.length === 0) {
+            setFeeSats(null);
+            return;
+        }
+        let cancelled = false;
+        (async () => {
+            setEstimating(true);
+            setFeeSats(null);
+            try {
+                if (selected === "strike" || selected === "coinos") {
+                    const est = await estimateSwapFee(selected, expiring.sats);
+                    if (!cancelled) setFeeSats(est?.feeSats ?? null);
+                } else {
+                    const addr = addressFor(selected);
+                    if (!addr) {
+                        if (!cancelled) setFeeSats(null);
+                        return;
+                    }
+                    const est = await estimateArkOffboardFee(addr, expiring.ids);
+                    if (!cancelled) setFeeSats(est.feeSats);
+                }
+            } catch {
+                if (!cancelled) setFeeSats(null);
+            } finally {
+                if (!cancelled) setEstimating(false);
+            }
+        })();
+        return () => {
+            cancelled = true;
+        };
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [selected, externalAddr, expiring.sats, expiring.ids.length]);
+
+    const handleExit = async () => {
+        if (!selected || expiring.ids.length === 0 || exiting) return;
+        setExiting(true);
+        setResult(null);
+        try {
+            if (selected === "strike" || selected === "coinos") {
+                // Ark LN fee is on top, so swap (sum - fee) to leave headroom.
+                const fee = feeSats ?? 0;
+                const amount = Math.max(0, expiring.sats - fee);
+                if (amount <= 0) throw new Error("Amount too small after the Lightning fee.");
+                await swap("ark", selected, amount);
+                setResult({
+                    ok: true,
+                    msg: `Moving ${amount.toLocaleString()} sats to ${selected === "strike" ? "Strike" : "Coinos"}.`,
+                });
+            } else {
+                const addr = addressFor(selected);
+                if (!addr) {
+                    setResult({ ok: false, msg: "Enter a valid Bitcoin address first." });
+                    setExiting(false);
+                    return;
+                }
+                await offboardArkVtxos(expiring.ids, addr);
+                setResult({
+                    ok: true,
+                    msg: `Moving ${expiring.sats.toLocaleString()} sats on-chain. It will confirm shortly.`,
+                });
+            }
+            try {
+                await syncArkWallet();
+                await Promise.all([fetchArkBalance(), fetchArkVtxos()]);
+            } catch {
+                // Non-fatal.
+            }
+        } catch (e: any) {
+            const inner = e?.inner?.errorMessage ?? e?.message ?? "The move failed.";
+            setResult({ ok: false, msg: `${inner} Your funds are unchanged, try another wallet.` });
+        } finally {
+            setExiting(false);
+        }
+    };
+
+    const accent = colors.ark?.light ?? colors.pink.default;
+    const options: { key: Dest; label: string; disabled: boolean }[] = [
+        { key: "strike", label: "Strike", disabled: !swapAvail.strike },
+        { key: "coinos", label: "Coinos", disabled: !swapAvail.coinos },
+        { key: "hot", label: "Hot Vault (on-chain)", disabled: !walletID },
+        { key: "cold", label: "Cold Vault (on-chain)", disabled: !coldStorageWalletID },
+        { key: "external", label: "External Bitcoin address (on-chain)", disabled: false },
+    ];
+
+    const canExit =
+        !!selected &&
+        expiring.ids.length > 0 &&
+        !estimating &&
+        !exiting &&
+        (!isOnchain(selected) || !!addressFor(selected));
+
+    // ----- render -----
+    if (preparing) {
+        return (
+            <ScreenLayout showToolbar isBackButton title="Stuck refresh">
+                <View style={{ flex: 1, alignItems: "center", justifyContent: "center", padding: 24 }}>
+                    <ActivityIndicator color={accent} />
+                    <Text style={{ fontSize: 13, color: "#CCC", marginTop: 12 }}>
+                        Unlocking your capsules…
+                    </Text>
+                </View>
+            </ScreenLayout>
+        );
+    }
+
+    if (result) {
+        return (
+            <ScreenLayout showToolbar isBackButton title="Stuck refresh">
+                <View style={{ flex: 1, padding: 24 }}>
+                    <Text bold style={{ fontSize: 18, color: result.ok ? colors.green : colors.redLight, marginBottom: 12 }}>
+                        {result.ok ? "Funds on the way" : "Move failed"}
+                    </Text>
+                    <Text style={{ fontSize: 13, color: "#CCC", lineHeight: 19 }}>{result.msg}</Text>
+                    {!result.ok && (
+                        <TouchableOpacity
+                            onPress={() => setResult(null)}
+                            activeOpacity={0.7}
+                            style={{ marginTop: 20, paddingVertical: 13, borderRadius: 10, alignItems: "center", backgroundColor: accent }}
+                        >
+                            <Text bold style={{ fontSize: 14, color: "#0B0B0B" }}>Try another wallet</Text>
+                        </TouchableOpacity>
+                    )}
+                </View>
+            </ScreenLayout>
+        );
+    }
+
+    return (
+        <ScreenLayout showToolbar isBackButton title="Stuck refresh">
+            <ScrollView style={{ flex: 1 }} contentContainerStyle={{ paddingHorizontal: 24, paddingTop: 16, paddingBottom: 40 }}>
+                <Text bold style={{ fontSize: 18, color: colors.redLight, lineHeight: 24, marginBottom: 12 }}>
+                    Your {expiring.sats.toLocaleString()} sats lightning capsule (VTXO) is caught in a stuck-refresh loop
+                </Text>
+                <Text style={{ fontSize: 13, color: "#CCC", lineHeight: 19, marginBottom: 10 }}>
+                    This is an ASP-side problem, not Cypher Box. Refresh rounds run on the Ark
+                    server. When a round wedges, your capsule stays locked and keeps retrying
+                    instead of finishing.
+                </Text>
+                <Text style={{ fontSize: 13, color: "#CCC", lineHeight: 19, marginBottom: 12 }}>
+                    Your funds are safe, but the capsule still has an expiry. The safe move is to{" "}
+                    <Text bold style={{ fontSize: 13, color: "#FFF", lineHeight: 19 }}>
+                        move the funds into another wallet before it expires
+                    </Text>
+                    .
+                </Text>
+
+                {expiring.ids.length === 0 ? (
+                    <Text style={{ fontSize: 13, color: colors.green, lineHeight: 19, marginTop: 8 }}>
+                        No capsules are near expiry right now. The stuck refresh cleared and your
+                        funds are safe.
+                    </Text>
+                ) : (
+                    <>
+                        <View style={{ marginTop: 4, marginBottom: 8, padding: 12, borderRadius: 10, backgroundColor: "rgba(255,255,255,0.04)" }}>
+                            <Text bold style={{ fontSize: 14, color: "#FFF" }}>
+                                {expiring.ids.length} capsule{expiring.ids.length === 1 ? "" : "s"} about to expire
+                            </Text>
+                            <Text style={{ fontSize: 13, color: "#BBB", marginTop: 2 }}>
+                                {expiring.sats.toLocaleString()} sats total
+                            </Text>
+                        </View>
+
+                        <Text bold style={{ fontSize: 14, color: accent, marginTop: 12, marginBottom: 8 }}>
+                            Move them to
+                        </Text>
+                        {options.map((opt) => {
+                            const isSel = selected === opt.key;
+                            return (
+                                <TouchableOpacity
+                                    key={opt.key}
+                                    onPress={opt.disabled ? undefined : () => setSelected(opt.key)}
+                                    disabled={opt.disabled}
+                                    activeOpacity={0.7}
+                                    accessibilityRole="radio"
+                                    accessibilityState={{ selected: isSel, disabled: opt.disabled }}
+                                    accessibilityLabel={opt.label}
+                                    style={{
+                                        flexDirection: "row",
+                                        alignItems: "center",
+                                        marginBottom: 8,
+                                        paddingVertical: 12,
+                                        paddingHorizontal: 14,
+                                        borderRadius: 10,
+                                        borderWidth: 1,
+                                        borderColor: isSel ? accent : "#333",
+                                        backgroundColor: isSel ? "rgba(255,255,255,0.05)" : "transparent",
+                                        opacity: opt.disabled ? 0.4 : 1,
+                                    }}
+                                >
+                                    <View style={{ width: 18, height: 18, borderRadius: 9, borderWidth: 2, borderColor: isSel ? accent : "#777", marginRight: 12, alignItems: "center", justifyContent: "center" }}>
+                                        {isSel && <View style={{ width: 8, height: 8, borderRadius: 4, backgroundColor: accent }} />}
+                                    </View>
+                                    <Text bold style={{ fontSize: 14, color: "#FFF" }}>{opt.label}</Text>
+                                </TouchableOpacity>
+                            );
+                        })}
+
+                        {selected === "external" && (
+                            <TextInput
+                                value={externalAddr}
+                                onChangeText={setExternalAddr}
+                                placeholder="Paste a Bitcoin address"
+                                placeholderTextColor="#777"
+                                autoCapitalize="none"
+                                autoCorrect={false}
+                                style={{ marginTop: 2, marginBottom: 8, borderWidth: 1, borderColor: "#444", borderRadius: 8, paddingVertical: 10, paddingHorizontal: 12, color: "#FFF", fontSize: 13 }}
+                            />
+                        )}
+
+                        {selected && (
+                            <View style={{ marginTop: 8, padding: 12, borderRadius: 10, borderWidth: 1, borderColor: "#333" }}>
+                                {estimating ? (
+                                    <View style={{ flexDirection: "row", alignItems: "center" }}>
+                                        <ActivityIndicator color={accent} />
+                                        <Text style={{ fontSize: 13, color: "#BBB", marginLeft: 10 }}>Estimating fee…</Text>
+                                    </View>
+                                ) : (
+                                    <Text style={{ fontSize: 13, color: "#DDD", lineHeight: 19 }}>
+                                        {isOnchain(selected) && !addressFor(selected)
+                                            ? "Enter a valid Bitcoin address to see the fee."
+                                            : feeSats == null
+                                            ? "Fee unavailable, you can still continue."
+                                            : `Fee: ${feeSats.toLocaleString()} sats`}
+                                    </Text>
+                                )}
+                            </View>
+                        )}
+
+                        <TouchableOpacity
+                            onPress={canExit ? handleExit : undefined}
+                            disabled={!canExit}
+                            activeOpacity={0.7}
+                            accessibilityRole="button"
+                            accessibilityLabel="Exit"
+                            style={{ marginTop: 16, paddingVertical: 14, borderRadius: 12, alignItems: "center", backgroundColor: canExit ? accent : "#444" }}
+                        >
+                            {exiting ? (
+                                <ActivityIndicator color="#0B0B0B" />
+                            ) : (
+                                <Text bold style={{ fontSize: 15, color: "#0B0B0B" }}>Exit</Text>
+                            )}
+                        </TouchableOpacity>
+                    </>
+                )}
+            </ScrollView>
+        </ScreenLayout>
+    );
+}

--- a/src/screens/HomeScreen/WalletsView/index.tsx
+++ b/src/screens/HomeScreen/WalletsView/index.tsx
@@ -892,6 +892,13 @@ const WalletsView = forwardRef<WalletsViewHandle, Props>(function WalletsView({
                         onPress={() => {
                             const stuck = useAuthStore.getState().arkRefreshStuck;
                             if (!stuck) return;
+                            // Near expiry: refreshing is stuck AND the funds are
+                            // running out, so route to the "move your funds out"
+                            // screen rather than the in-place cancel-and-retry.
+                            if (stuck.nearExpiry) {
+                                dispatchNavigate('ArkStuckCapsuleScreen', {});
+                                return;
+                            }
                             (async () => {
                                 for (const roundId of stuck.stuckRoundIds) {
                                     try {
@@ -905,7 +912,9 @@ const WalletsView = forwardRef<WalletsViewHandle, Props>(function WalletsView({
                         }}
                         activeOpacity={0.7}
                         accessibilityRole="button"
-                        accessibilityLabel="Recover stuck refresh"
+                        accessibilityLabel={arkRefreshStuck.nearExpiry
+                            ? 'Move your stuck funds out'
+                            : 'Recover stuck refresh'}
                     >
                         <Text
                             h4
@@ -916,7 +925,9 @@ const WalletsView = forwardRef<WalletsViewHandle, Props>(function WalletsView({
                                 textDecorationLine: 'underline',
                             }}
                         >
-                            Refresh stuck · {arkRefreshStuck.stuckSats.toLocaleString()} sats. Tap to recover
+                            {arkRefreshStuck.nearExpiry
+                                ? `Warning: Refresh stuck near expiry · ${arkRefreshStuck.stuckSats.toLocaleString()} sats. Tap to move funds out`
+                                : `Refresh stuck · ${arkRefreshStuck.stuckSats.toLocaleString()} sats. Tap to recover`}
                         </Text>
                     </TouchableOpacity>
                 </Animated.View>

--- a/src/screens/Strike/CheckingAccountNew/ArkCapsules.tsx
+++ b/src/screens/Strike/CheckingAccountNew/ArkCapsules.tsx
@@ -1899,6 +1899,45 @@ export default function ArkCapsules({ matchedRate, currency }: ArkCapsulesProps)
                 </View>
             </View>
 
+            {/* DEV-ONLY stuck-refresh test harness. Never renders in a release
+                build (__DEV__ is false). Lets us exercise the swap-out UX
+                without a real ASP-side wedge: "Simulate stuck" injects a
+                near-expiry stuck state (empty roundIds so nothing real is
+                cancelled) which lights up the home-card + Capsules banners and
+                makes ArkStuckCapsuleScreen reachable; "Fire notification"
+                fires the 12h swap-out push immediately to test its content +
+                tap routing; "Clear" removes the simulated state. */}
+            {/* Commented out for release. To re-enable on-device testing,
+                uncomment this block AND re-add `notifyStuckSwapNow` to the
+                @Cypher/services/ark import above. It is __DEV__-gated so it
+                never renders in production either way.
+            {__DEV__ && (
+                <View style={{ marginHorizontal: 20, marginBottom: 10, padding: 10, borderRadius: 8, borderWidth: 1, borderColor: '#555', borderStyle: 'dashed' }}>
+                    <Text bold style={{ fontSize: 11, color: '#888', marginBottom: 6 }}>DEV: stuck-refresh test</Text>
+                    <View style={{ flexDirection: 'row', flexWrap: 'wrap' }}>
+                        <TouchableOpacity
+                            onPress={() => setArkRefreshStuck({ stuckRoundIds: [], stuckSats: 12500, detectedAtTip: chainTipHeight ?? 0, nearExpiry: true })}
+                            style={{ paddingVertical: 7, paddingHorizontal: 12, borderRadius: 6, backgroundColor: '#333', marginRight: 8, marginBottom: 6 }}
+                        >
+                            <Text style={{ fontSize: 12, color: '#EEE' }}>Simulate stuck</Text>
+                        </TouchableOpacity>
+                        <TouchableOpacity
+                            onPress={() => notifyStuckSwapNow(12500)}
+                            style={{ paddingVertical: 7, paddingHorizontal: 12, borderRadius: 6, backgroundColor: '#333', marginRight: 8, marginBottom: 6 }}
+                        >
+                            <Text style={{ fontSize: 12, color: '#EEE' }}>Fire notification</Text>
+                        </TouchableOpacity>
+                        <TouchableOpacity
+                            onPress={() => setArkRefreshStuck(null)}
+                            style={{ paddingVertical: 7, paddingHorizontal: 12, borderRadius: 6, backgroundColor: '#333', marginBottom: 6 }}
+                        >
+                            <Text style={{ fontSize: 12, color: '#EEE' }}>Clear</Text>
+                        </TouchableOpacity>
+                    </View>
+                </View>
+            )}
+            */}
+
             {/* Stuck-refresh recovery banner. The equivalent home-card banner
                 (ArkWallet) is invisible to a user sitting on this tab watching
                 a capsule pulse "Refreshing…" — which is exactly when they need
@@ -1908,10 +1947,18 @@ export default function ArkCapsules({ matchedRate, currency }: ArkCapsulesProps)
                 VTXOs. */}
             {arkRefreshStuck && (
                 <TouchableOpacity
-                    onPress={handleStuckRecovery}
+                    // Near expiry: refreshing is stuck AND the funds are running
+                    // out, so this becomes the Capsules-tab entry point into the
+                    // "move your funds out" screen. Otherwise keep the in-place
+                    // cancel-and-retry recovery.
+                    onPress={arkRefreshStuck.nearExpiry
+                        ? () => dispatchNavigate('ArkStuckCapsuleScreen', {})
+                        : handleStuckRecovery}
                     activeOpacity={0.7}
                     accessibilityRole="button"
-                    accessibilityLabel="Recover stuck refresh"
+                    accessibilityLabel={arkRefreshStuck.nearExpiry
+                        ? 'Move your stuck funds out'
+                        : 'Recover stuck refresh'}
                     style={{
                         marginHorizontal: 20,
                         marginBottom: 10,
@@ -1924,13 +1971,26 @@ export default function ArkCapsules({ matchedRate, currency }: ArkCapsulesProps)
                     }}
                 >
                     <Text bold style={{ color: colors.redLight, fontSize: 13, lineHeight: 18 }}>
-                        Refresh stuck for {arkRefreshStuck.stuckSats.toLocaleString()} sats.{' '}
-                        <Text bold style={{ color: colors.redLight, textDecorationLine: 'underline' }}>
-                            Tap to recover.
-                        </Text>
+                        {arkRefreshStuck.nearExpiry ? (
+                            <>
+                                Warning: Refresh stuck near expiry · {arkRefreshStuck.stuckSats.toLocaleString()} sats.{' '}
+                                <Text bold style={{ color: colors.redLight, textDecorationLine: 'underline' }}>
+                                    Tap to move funds out
+                                </Text>
+                            </>
+                        ) : (
+                            <>
+                                Refresh stuck for {arkRefreshStuck.stuckSats.toLocaleString()} sats.{' '}
+                                <Text bold style={{ color: colors.redLight, textDecorationLine: 'underline' }}>
+                                    Tap to recover.
+                                </Text>
+                            </>
+                        )}
                     </Text>
                     <Text style={{ color: '#B0B0B0', fontSize: 11, marginTop: 3, lineHeight: 15 }}>
-                        This round is taking longer than expected. Recovering unlocks your capsules so you can try again. Your funds are safe.
+                        {arkRefreshStuck.nearExpiry
+                            ? 'Refresh process is stuck and some capsules are about to expire. Tap to move funds to another wallet before they expire.'
+                            : 'This round is taking longer than expected. Recovering unlocks your capsules so you can try again. Your funds are safe.'}
                     </Text>
                 </TouchableOpacity>
             )}

--- a/src/screens/Strike/CheckingAccountNew/ArkCapsules.tsx
+++ b/src/screens/Strike/CheckingAccountNew/ArkCapsules.tsx
@@ -825,6 +825,146 @@ interface ArkCapsulesProps {
  */
 const TAP_REFRESH_IMMINENT_DAYS = 14;
 
+// Countdown window for the refresh-wait reminder. Each in-flight round gets a
+// 3h timer counting down from when it started (its first-seen timestamp).
+const REFRESH_WAIT_WINDOW_MS = 3 * 60 * 60 * 1000;
+// Cap the stacked per-round countdown lines so spam-tapping (which queues
+// duplicate rounds) can't grow the banner unbounded; the rest collapse to
+// a "+N more" line.
+const MAX_EXTRA_REFRESH_LINES = 3;
+
+// Format a remaining-ms value as H:MM:SS (e.g. 2:59:59). Clamped at 0.
+function formatCountdown(ms: number): string {
+    const total = Math.max(0, Math.floor(ms / 1000));
+    const h = Math.floor(total / 3600);
+    const m = Math.floor((total % 3600) / 60);
+    const s = total % 60;
+    return `${h}:${String(m).padStart(2, '0')}:${String(s).padStart(2, '0')}`;
+}
+
+/**
+ * Green pulsing reminder shown while a refresh round is in flight. A round can
+ * take up to a few hours to finalise (or time out) server-side, and the user
+ * must be back in the app for the completion sync to land, so we nudge them to
+ * return, with a live countdown per in-flight round.
+ *
+ * `roundStarts` is the set of round first-seen timestamps (ms) from
+ * `arkPendingRoundFirstSeen`, one per in-flight round. Each gets a 3h
+ * countdown; the soonest-to-elapse (oldest round) is shown inline in the
+ * headline and the rest stack below as "Refresh 2 / 3 / ...". A line drops
+ * when its round completes (pruned from the map upstream). If a round is still
+ * present after its 3h window is up it hasn't completed, so the banner switches
+ * to a "stuck" state with a Cancel action; cancelling clears the round, which
+ * unmounts the banner via the caller's in-flight gate. Self-contained pulse +
+ * 1s tick so only this component re-renders each second, not the capsule list.
+ */
+function RefreshWaitBanner({
+    roundStarts,
+    cancelling,
+    onCancel,
+}: {
+    roundStarts: number[];
+    cancelling: boolean;
+    onCancel: () => void;
+}) {
+    const pulse = useRef(new Animated.Value(0.6)).current;
+    const [now, setNow] = useState(Date.now());
+    useEffect(() => {
+        const loop = Animated.loop(
+            Animated.sequence([
+                Animated.timing(pulse, {
+                    toValue: 1,
+                    duration: 900,
+                    easing: Easing.inOut(Easing.ease),
+                    useNativeDriver: true,
+                }),
+                Animated.timing(pulse, {
+                    toValue: 0.6,
+                    duration: 900,
+                    easing: Easing.inOut(Easing.ease),
+                    useNativeDriver: true,
+                }),
+            ]),
+        );
+        loop.start();
+        const tick = setInterval(() => setNow(Date.now()), 1000);
+        return () => {
+            loop.stop();
+            clearInterval(tick);
+        };
+    }, [pulse]);
+
+    // A round still tracked after its 3h window has elapsed hasn't completed:
+    // treat it as stuck. Otherwise render the per-round countdowns, soonest-to-
+    // elapse first (the oldest round is the headline timer; the rest stack).
+    const isStuck = roundStarts.some((start) => now - start >= REFRESH_WAIT_WINDOW_MS);
+    const counting = roundStarts
+        .map((start) => ({ start, remaining: start + REFRESH_WAIT_WINDOW_MS - now }))
+        .filter((x) => x.remaining > 0)
+        .sort((a, b) => a.remaining - b.remaining);
+    const primary = counting[0];
+    const extras = counting.slice(1);
+
+    // Always amber: this is a "come back and check" warning whether the round
+    // is still counting down or already stuck.
+    const accent = '#FFD54F';
+    const tint = 'rgba(255, 213, 79, 0.10)';
+
+    return (
+        <Animated.View
+            style={{
+                // Steady (no pulse) once stuck so the amber warning reads as a
+                // fixed alert and the Cancel button stays easy to tap.
+                opacity: isStuck ? 1 : pulse,
+                marginHorizontal: 24,
+                marginBottom: 12,
+                paddingVertical: 12,
+                paddingHorizontal: 14,
+                borderRadius: 10,
+                backgroundColor: tint,
+                borderWidth: 1,
+                borderColor: accent,
+            }}
+        >
+            {isStuck ? (
+                <>
+                    <Text bold center style={{ fontSize: 12, color: accent, letterSpacing: 0.5, lineHeight: 17 }}>
+                        This refresh is stuck. You can cancel the refresh and try again later.
+                    </Text>
+                    <TouchableOpacity
+                        onPress={cancelling ? undefined : onCancel}
+                        style={{ marginTop: 10, paddingVertical: 8, borderRadius: 8, alignItems: 'center', borderWidth: 1, borderColor: accent }}
+                    >
+                        <Text bold style={{ fontSize: 12, color: accent }}>
+                            {cancelling ? 'Cancelling…' : 'Cancel refresh'}
+                        </Text>
+                    </TouchableOpacity>
+                </>
+            ) : (
+                <>
+                    <Text bold center style={{ fontSize: 12, color: accent, letterSpacing: 0.5, lineHeight: 17 }}>
+                        {`PLEASE COME BACK IN 3 HOURS TO MAKE SURE THE REFRESH HAS COMPLETED${primary ? ` (${formatCountdown(primary.remaining)})` : ''}`}
+                    </Text>
+                    {extras.slice(0, MAX_EXTRA_REFRESH_LINES).map((x, i) => (
+                        <Text
+                            key={x.start}
+                            center
+                            style={{ fontSize: 11, color: accent, marginTop: 4 }}
+                        >
+                            {`- Refresh ${i + 2}: ${formatCountdown(x.remaining)}`}
+                        </Text>
+                    ))}
+                    {extras.length > MAX_EXTRA_REFRESH_LINES && (
+                        <Text center style={{ fontSize: 11, color: accent, marginTop: 4 }}>
+                            {`+${extras.length - MAX_EXTRA_REFRESH_LINES} more`}
+                        </Text>
+                    )}
+                </>
+            )}
+        </Animated.View>
+    );
+}
+
 export default function ArkCapsules({ matchedRate, currency }: ArkCapsulesProps) {
     const [selectedIds, setSelectedIds] = useState<string[]>([]);
     const [refreshing, setRefreshing] = useState(false);
@@ -862,6 +1002,10 @@ export default function ArkCapsules({ matchedRate, currency }: ArkCapsulesProps)
     const setArkPendingTapRefresh = useAuthStore((s) => s.setArkPendingTapRefresh);
     const arkRefreshStuck = useAuthStore((s) => s.arkRefreshStuck);
     const setArkRefreshStuck = useAuthStore((s) => s.setArkRefreshStuck);
+    // Per-round first-seen timestamps (round id -> ms), maintained by
+    // useArkSync's stuck detection. Drives the per-round 3h countdowns in the
+    // refresh-wait banner. Auto-prunes when a round completes.
+    const arkPendingRoundFirstSeen = useAuthStore((s) => s.arkPendingRoundFirstSeen);
 
     // Recover a stuck refresh from the Capsules tab. Mirrors the home-card
     // handler in ArkWallet — but that banner is invisible to a user sitting
@@ -1831,6 +1975,18 @@ export default function ArkCapsules({ matchedRate, currency }: ArkCapsulesProps)
         </GradientView>
     );
 
+    // Refresh-in-flight signals for the action button + wait banner.
+    // `roundInFlight` (any Locked VTXO) is the same signal that flips the
+    // per-row refresh icon to a cancel-X, and it persists for the whole round
+    // (up to a few hours), so it drives the "Cancel" label and the banner.
+    // `refreshing` is the brief local submit phase before the round is Locked.
+    const roundInFlight = pendingRoundSats > 0;
+    const refreshInFlight = refreshing || roundInFlight;
+    // Round start timestamps for the wait-banner countdowns. Values are the
+    // first-seen ms per in-flight round; the banner turns each into a 3h
+    // countdown and drops it when it elapses or its round completes.
+    const roundStarts = Object.values(arkPendingRoundFirstSeen ?? {});
+
     return (
         <View style={vaultStyles.flex}>
             {/* Header block: prominent Auto-refresh on/off status on the
@@ -1848,25 +2004,6 @@ export default function ArkCapsules({ matchedRate, currency }: ArkCapsulesProps)
                         {arkBgRefreshEnabled ? 'on' : 'off'}
                     </Text>
                 </Text>
-                {/* Wallet-policy refresh deadline. Always shown when the SDK
-                    has a value, regardless of whether auto-refresh is on —
-                    a user with auto-refresh off still needs to know when
-                    to manually act. Hidden when nextRefreshBlocks is null
-                    (no spendable VTXOs / all already refreshed within
-                    policy margin) so the line doesn't render as broken
-                    state on a fresh / empty wallet. */}
-                {nextRefreshBlocks !== null && (
-                    <Text
-                        style={{
-                            fontSize: 12,
-                            color: '#888',
-                            marginTop: -2,
-                            marginBottom: 6,
-                        }}
-                    >
-                        {`Next refresh ${formatBlocksUntil(nextRefreshBlocks)}`}
-                    </Text>
-                )}
                 <View style={{ flexDirection: 'row', alignItems: 'center', alignSelf: 'stretch' }}>
                     <Text style={{ fontSize: 13, color: '#888', flex: 1 }}>
                         Your lightning capsules (VTXOs) must be refreshed before they expire, or they are lost forever.{' '}
@@ -1997,12 +2134,15 @@ export default function ArkCapsules({ matchedRate, currency }: ArkCapsulesProps)
             <View style={vaultStyles.titleStyle}>
                 <Text bold style={vaultStyles.coin}>Capsules</Text>
                 <Text bold style={vaultStyles.size}>Size</Text>
+                {/* Column header for the per-row refresh/cancel icons. Flips to
+                    "Cancel" while a round is in flight, matching the per-row
+                    icons that switch from the refresh arrows to a cancel-X. */}
                 <Text
                     bold
                     numberOfLines={1}
                     style={[vaultStyles.label, { fontSize: 18, textAlign: 'left', marginLeft: -8, flex: 1.35 }]}
                 >
-                    Refresh
+                    {roundInFlight ? 'Cancel' : 'Refresh'}
                 </Text>
                 <Text bold style={vaultStyles.select}>Select</Text>
             </View>
@@ -2079,6 +2219,17 @@ export default function ArkCapsules({ matchedRate, currency }: ArkCapsulesProps)
                 de-clutters the screen. No Emergency Exit here — that's
                 the global Withdraw button's job, see the file docblock. */}
             <View style={vaultStyles.bottomViewNew}>
+                {/* Green pulsing "come back in 3 hours" reminder while a
+                    refresh round is in flight (or being submitted), with a
+                    live 3h countdown per in-flight round. Flips to a stuck
+                    state with a Cancel action once a round's 3h elapses. */}
+                {refreshInFlight && (
+                    <RefreshWaitBanner
+                        roundStarts={roundStarts}
+                        cancelling={cancelling}
+                        onCancel={handleRowCancel}
+                    />
+                )}
                 <View style={{ flexDirection: "row", justifyContent: "center", alignItems: "center", marginBottom: 12 }}>
                     {renderActionButton("Send", handleSend)}
                     {renderActionButton(

--- a/src/screens/Strike/CheckingAccountNew/Settings.tsx
+++ b/src/screens/Strike/CheckingAccountNew/Settings.tsx
@@ -31,10 +31,14 @@ import styles from "./styles";
 import { getStrikeProfile, getStrikeLimits, getBankPaymentMethods } from "@Cypher/api/strikeAPIs";
 import {
   AUTO_BACKUP_PATH,
+  computeExitFeeReserveSats,
   connectGoogleDrive,
+  convertToExitFees,
   disconnectGoogleDrive,
+  estimateExitFeeConvert,
   fetchPendingExitsTotalSats,
   findAutoBackupForRecovery,
+  getArkOnchainAddress,
   getAutoBackupPath,
   getCachedArkBackupFingerprint,
   getDriveBackupInfo,
@@ -43,12 +47,14 @@ import {
   getLastLocalBackupNote,
   isGoogleDriveConnected,
   isICloudBackupAvailable,
+  probeAspReachable,
   readArkSeedPhrase,
   resetArkWalletState,
   setArkBackgroundRefreshEnabled,
   startArkEmergencyExit,
   writeArkBackupToTempFile,
 } from "@Cypher/services/ark";
+import type { ExitFeeConvertEstimate } from "@Cypher/services/ark";
 import RNFS from "react-native-fs";
 import Share from "react-native-share";
 import { BlueStorageContext } from "../../../../blue_modules/storage-context";
@@ -313,12 +319,15 @@ export function ArkSettingsBody({ view = 'backup' }: { view?: 'backup' | 'action
     clearArkAuth,
     walletID,
     coldStorageWalletID,
+    arkBalanceDetail,
     arkExitInProgress,
     arkExitDestinationAddress,
     arkExitStartedAt,
+    arkExitFeeReserveSats,
     setArkExitInProgress,
     setArkExitDestinationAddress,
     setArkExitStartedAt,
+    setArkExitFeeReserveSats,
   } = useAuthStore() as any;
   const arkIosBackupReminderActive = useAuthStore((s) => s.arkIosBackupReminderActive);
   const setArkIosBackupReminderActive = useAuthStore((s) => s.setArkIosBackupReminderActive);
@@ -857,6 +866,45 @@ export function ArkSettingsBody({ view = 'backup' }: { view?: 'backup' | 'action
   const [exitStarting, setExitStarting] = useState(false);
   const [pendingExitSats, setPendingExitSats] = useState<number | null>(null);
 
+  // --- Exit-fee funding gate ---
+  //
+  // The unilateral exit pays its on-chain CPFP fees from a SEPARATE bark
+  // on-chain (BDK) wallet that a Lightning-only user never funds (holds 0
+  // sats), so an unfunded exit silently stalls. We recommend an on-chain
+  // reserve sized from the VTXOs' own exit weights (computeExitFeeReserveSats)
+  // and gate Emergency Exit until the on-chain balance
+  // (arkBalanceDetail.onchainBoardingSats, refreshed each sync tick) meets it.
+  // `null` while the first computation is in flight.
+  const [recommendedReserveSats, setRecommendedReserveSats] = useState<number | null>(null);
+  const [exitFundingOpen, setExitFundingOpen] = useState(false);
+  const [fundingTab, setFundingTab] = useState<'receive' | 'convert'>('receive');
+  const [onchainFundAddr, setOnchainFundAddr] = useState<string | null>(null);
+  // ASP reachability for the CONVERT (cooperative-offboard) tab. null = probing.
+  const [aspReachable, setAspReachable] = useState<boolean | null>(null);
+  const [convertAmount, setConvertAmount] = useState('');
+  const [convertEst, setConvertEst] = useState<ExitFeeConvertEstimate | null>(null);
+  const [fundingBusy, setFundingBusy] = useState(false);
+  // Editable reserve-target field (sats) in the funding modal. Lets the user
+  // hold more than the recommendation (bigger fee-spike buffer) or less.
+  const [reserveTargetInput, setReserveTargetInput] = useState('');
+
+  const onchainReserveSats: number = arkBalanceDetail?.onchainBoardingSats ?? 0;
+  // Reserve target: the user's chosen hold amount if they've set/armed one
+  // (persisted), otherwise the computed recommendation. Drives the gate, the
+  // funded state, and (via arkExitFeeReserveSats) how much auto-board keeps
+  // on-chain. While recommended is still null (first compute) and nothing is
+  // armed, the target is 0 so we don't gate; the button shows "checking".
+  const reserveTargetSats: number =
+    (arkExitFeeReserveSats ?? 0) > 0 ? arkExitFeeReserveSats : (recommendedReserveSats ?? 0);
+  const exitFeeGated = reserveTargetSats > 0 && onchainReserveSats < reserveTargetSats;
+  const exitFeeShortfallSats = Math.max(0, reserveTargetSats - onchainReserveSats);
+  const exitFeeFunded = reserveTargetSats > 0 && onchainReserveSats >= reserveTargetSats;
+  // The user armed a target below the recommended safe amount (warn them).
+  const reserveBelowRecommended =
+    (arkExitFeeReserveSats ?? 0) > 0 &&
+    (recommendedReserveSats ?? 0) > 0 &&
+    arkExitFeeReserveSats < (recommendedReserveSats ?? 0);
+
   // Reset transient picker state whenever the modal closes so the next open
   // starts from category step with no stale selection / checkbox carry-over.
   useEffect(() => {
@@ -894,6 +942,166 @@ export function ArkSettingsBody({ view = 'backup' }: { view?: 'backup' | 'action
       clearInterval(id);
     };
   }, [arkExitInProgress]);
+
+  // Compute the recommended exit-fee reserve when the actions tab is showing
+  // and no exit is in flight. computeExitFeeReserveSats runs the JS-thread-
+  // blocking allVtxos() call, so it lives in an effect (off the render path),
+  // keyed on the spendable balance so it re-sizes when the VTXO set changes.
+  useEffect(() => {
+    if (view !== 'actions' || arkExitInProgress) return;
+    let cancelled = false;
+    (async () => {
+      try {
+        const r = await computeExitFeeReserveSats();
+        if (!cancelled) setRecommendedReserveSats(r.recommendedSats);
+      } catch (err) {
+        // Leave any prior recommendation in place; a transient failure
+        // shouldn't flip a gated wallet to ungated.
+        if (__DEV__) console.warn('[Ark exit-funding] reserve compute failed:', err);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [view, arkExitInProgress, arkBalanceDetail?.spendableSats]);
+
+  // When the funding modal opens: fetch a fresh on-chain address (RECEIVE tab)
+  // and probe ASP reachability (gates the CONVERT tab).
+  useEffect(() => {
+    if (!exitFundingOpen) return;
+    let cancelled = false;
+    (async () => {
+      try {
+        const addr = await getArkOnchainAddress();
+        if (!cancelled) setOnchainFundAddr(addr);
+      } catch (err) {
+        if (__DEV__) console.warn('[Ark exit-funding] onchain address fetch failed:', err);
+      }
+      try {
+        const ok = await probeAspReachable();
+        if (!cancelled) setAspReachable(ok);
+      } catch {
+        if (!cancelled) setAspReachable(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [exitFundingOpen]);
+
+  // Debounced fee estimate for the CONVERT tab. Skipped when the ASP is known
+  // unreachable (the offboard would fail) or the amount is empty/invalid.
+  useEffect(() => {
+    if (!exitFundingOpen || fundingTab !== 'convert') return;
+    const amt = parseInt(convertAmount, 10);
+    if (!Number.isFinite(amt) || amt <= 0 || aspReachable === false) {
+      setConvertEst(null);
+      return;
+    }
+    let cancelled = false;
+    const id = setTimeout(async () => {
+      try {
+        const est = await estimateExitFeeConvert(amt);
+        if (!cancelled) setConvertEst(est);
+      } catch (err) {
+        if (!cancelled) setConvertEst(null);
+        if (__DEV__) console.warn('[Ark exit-funding] convert estimate failed:', err);
+      }
+    }, 600);
+    return () => {
+      cancelled = true;
+      clearTimeout(id);
+    };
+  }, [exitFundingOpen, fundingTab, convertAmount, aspReachable]);
+
+  // Open the funding flow. ARM the reserve synchronously FIRST (before any
+  // address is shown or deposit can confirm), so an incoming deposit isn't
+  // auto-boarded back into a VTXO before the reserve is set (sync.ts reads
+  // arkExitFeeReserveSats to decide how much to keep on-chain).
+  const openExitFunding = () => {
+    // Seed the target from the user's current armed reserve if any, else the
+    // recommendation. Arm it so incoming deposits up to the target aren't
+    // auto-boarded away (sync.ts reads arkExitFeeReserveSats).
+    const current = (arkExitFeeReserveSats ?? 0) > 0 ? arkExitFeeReserveSats : (recommendedReserveSats ?? 0);
+    if (current > 0) setArkExitFeeReserveSats(current);
+    setReserveTargetInput(current > 0 ? String(current) : '');
+    setFundingTab('receive');
+    setConvertAmount(String(Math.max(0, current - onchainReserveSats)));
+    setConvertEst(null);
+    setAspReachable(null);
+    setOnchainFundAddr(null);
+    setExitFundingOpen(true);
+  };
+
+  // Apply an edited reserve target: this is how the user holds MORE than the
+  // recommendation (bigger buffer) or less. Arms arkExitFeeReserveSats so
+  // auto-board keeps exactly this much on-chain and boards any surplus.
+  const applyReserveTarget = () => {
+    const t = parseInt(reserveTargetInput, 10);
+    if (!Number.isFinite(t) || t < 0) {
+      setReserveTargetInput(String(reserveTargetSats));
+      return;
+    }
+    setArkExitFeeReserveSats(t);
+    setConvertAmount(String(Math.max(0, t - onchainReserveSats)));
+  };
+
+  // Release the reserve: stop holding on-chain funds for exit fees. If the
+  // balance clears the 50k board minimum it boards back into Ark on the next
+  // round; below that it stays on-chain and the user recovers it to a Bitcoin
+  // address from the Capsules tab (the ASP won't board sub-50k deposits).
+  const doReleaseReserve = () => {
+    Alert.alert(
+      'Release exit fees',
+      `Stop reserving ${onchainReserveSats.toLocaleString()} sats for Emergency Exit fees?\n\n` +
+        (onchainReserveSats >= 50000
+          ? 'They will board back into your Ark balance on the next round.'
+          : 'They are below the 50,000-sat board minimum, so they cannot go back into a capsule. They stay on-chain, where you can recover them to a Bitcoin address from the Capsules tab.'),
+      [
+        { text: 'Cancel', style: 'cancel' },
+        {
+          text: 'Release',
+          style: 'destructive',
+          onPress: () => {
+            setArkExitFeeReserveSats(0);
+            setExitFundingOpen(false);
+            SimpleToast.show('Exit fee reserve released.', SimpleToast.LONG);
+          },
+        },
+      ],
+    );
+  };
+
+  const doConvertToExitFees = async () => {
+    const amt = parseInt(convertAmount, 10);
+    if (!Number.isFinite(amt) || amt <= 0) {
+      SimpleToast.show('Enter an amount to convert.', SimpleToast.SHORT);
+      return;
+    }
+    if (aspReachable === false) {
+      SimpleToast.show('Ark server unreachable. Use Receive Bitcoin instead.', SimpleToast.LONG);
+      return;
+    }
+    setFundingBusy(true);
+    try {
+      // Re-arm defensively in case the reserve was cleared between open and now.
+      const rec = recommendedReserveSats ?? 0;
+      if (rec > 0) setArkExitFeeReserveSats(rec);
+      await convertToExitFees(amt);
+      setExitFundingOpen(false);
+      SimpleToast.show(
+        'Converting to on-chain fee funds. Emergency Exit unlocks once it confirms.',
+        SimpleToast.LONG,
+      );
+    } catch (e: any) {
+      Alert.alert(
+        'Could not convert',
+        String(e?.message || '') || 'The offboard failed. Your Ark funds are unchanged.',
+      );
+    } finally {
+      setFundingBusy(false);
+    }
+  };
 
   /**
    * Build a list of usable receive addresses for a BlueWallet HD wallet by
@@ -951,10 +1159,31 @@ export function ArkSettingsBody({ view = 'backup' }: { view?: 'backup' | 'action
   const startExitWithAddress = async (destLabel: string, address: string) => {
     setExitPickerOpen(false);
     setExitStarting(true);
+    // Re-estimate the exit-fee cost NOW: fee rates move between screen mount and
+    // this tap, so the warning must reflect the current shortfall rather than a
+    // stale mount-time number. If the on-chain fee wallet is short, advise the
+    // user to top up. It's a stall warning, not a hard block (progressExits
+    // resumes the moment fees are added).
+    let freshRecommended = recommendedReserveSats ?? 0;
+    try {
+      const fresh = await computeExitFeeReserveSats();
+      freshRecommended = fresh.recommendedSats;
+      setRecommendedReserveSats(fresh.recommendedSats);
+    } catch {
+      // Keep the last computed recommendation on a transient failure.
+    }
+    const shortfall = Math.max(0, freshRecommended - onchainReserveSats);
+    const underfunded = freshRecommended > 0 && shortfall > 0;
+    const underfundedPrefix = underfunded
+      ? `Your on-chain fee wallet holds ${onchainReserveSats.toLocaleString()} sats of about ${freshRecommended.toLocaleString()} needed for miner fees. Add about ${shortfall.toLocaleString()} sats more, or the exit may stall until you top up during the wait.\n\n`
+      : '';
     try {
       Alert.alert(
         'Emergency Exit',
-        `Forces your VTXO capsules onto the Bitcoin chain. Funds arrive at your ${destLabel} after a ~24-hour wait set by Bitcoin. Once you start, this can't be cancelled.\n\n${address}\n\n` +
+        underfundedPrefix +
+          `Forces your VTXO capsules onto the Bitcoin chain. Funds arrive at your ${destLabel} after a ~24-hour wait set by Bitcoin. Once you start, this can't be cancelled.\n\n` +
+          'Only start this if your soonest capsule is at least 1 day from expiry. The exit txs must confirm on-chain before then, so it is not a last-minute rescue.\n\n' +
+          `${address}\n\n` +
           'Cypher Box keeps the exit running in the background and removes this Ark wallet when the funds arrive.',
         [
           {
@@ -1493,9 +1722,6 @@ export function ArkSettingsBody({ view = 'backup' }: { view?: 'backup' | 'action
             sit next to the balance card. The Settings tab now only holds
             Seed Phrase + Ark backup file — true one-time setup. */}
         <View style={{ marginTop: 24 }}>
-          <Text bold style={{ fontSize: 16, color: colors.ark?.light ?? colors.pink.default, marginBottom: 8 }}>
-            Capsule expiry reminders
-          </Text>
           <View
             style={{
               paddingVertical: 10,
@@ -1539,7 +1765,7 @@ export function ArkSettingsBody({ view = 'backup' }: { view?: 'backup' | 'action
               }}
             >
               {arkBgRefreshEnabled
-                ? 'Cypher Box sends 5 reminders before any capsule expires (4 days, 2 days, 24 hours, 12 hours, and 6 hours before). Tap a reminder to open Cypher Box and refresh automatically. Without a refresh, expired capsules cannot be recovered.'
+                ? 'Cypher Box sends 5 reminders before any capsule expires (4 days, 2 days, 24 hours, 12 hours, and 6 hours before). Without a refresh, expired capsules cannot be recovered.'
                 : '⚠ Reminders are OFF. You must open Cypher Box yourself and refresh capsules before they expire. Expired capsules cannot be recovered.'}
             </Text>
 
@@ -1576,19 +1802,100 @@ export function ArkSettingsBody({ view = 'backup' }: { view?: 'backup' | 'action
             {/* Emergency Exit — sits ABOVE Delete Ark vault. Yellow text
                 rather than red so users don't conflate it with the
                 irreversible "Delete vault" path; the Alert in
-                startExitWithAddress carries the full warning. */}
+                startExitWithAddress carries the full warning.
+
+                Disabled while the on-chain fee reserve is still being sized
+                (recommendedReserveSats === null) or below the recommendation
+                (exitFeeGated). When gated, the amber block below explains why
+                and offers "Fund exit fees" + a "Start exit anyway" break-glass. */}
             <GradientView
-              style={{ marginTop: 30, alignSelf: 'center', height: 38, width: widths * 0.5, shadowColor: '#040404', shadowOffset: { width: 8, height: 8 }, shadowOpacity: 0.8, shadowRadius: 16, elevation: 8 }}
+              style={{ marginTop: 30, alignSelf: 'center', height: 38, width: widths * 0.5, shadowColor: '#040404', shadowOffset: { width: 8, height: 8 }, shadowOpacity: 0.8, shadowRadius: 16, elevation: 8, opacity: (exitStarting || recommendedReserveSats === null || exitFeeGated) ? 0.45 : 1 }}
               linearGradientStyle={{ shadowColor: '#27272C', shadowOffset: { width: -8, height: -8 }, shadowOpacity: 0.48, shadowRadius: 12, elevation: 8 }}
               topShadowStyle={{ shadowOffset: { width: 2, height: 2 }, shadowRadius: 2, shadowColor: colors.ark?.shadowTopNew ?? '#E85C5A', borderRadius: 24, height: 38, width: widths * 0.5, justifyContent: 'center', alignItems: 'center' }}
               bottomShadowStyle={{ shadowOffset: { width: -2, height: -2 }, shadowRadius: 2, shadowOpacity: 1, shadowColor: '#030303', borderRadius: 24, height: 38, width: widths * 0.5, justifyContent: 'center', position: 'absolute' }}
               linearGradientStyleMain={{ borderRadius: 24, height: 38, width: widths * 0.5, justifyContent: 'center', alignItems: 'center' }}
-              onPress={exitStarting ? undefined : () => setExitPickerOpen(true)}
+              onPress={(exitStarting || recommendedReserveSats === null || exitFeeGated) ? undefined : () => setExitPickerOpen(true)}
             >
               <Text h3 bold center style={{ color: colors.ark?.light ?? colors.pink.default }}>
-                {exitStarting ? 'Starting exit…' : 'Emergency Exit'}
+                {exitStarting
+                  ? 'Starting exit…'
+                  : recommendedReserveSats === null
+                    ? 'Checking exit fees…'
+                    : 'Emergency Exit'}
               </Text>
             </GradientView>
+
+            {/* Fee-funding gate: on-chain fee wallet is short. Explain, offer
+                "Fund exit fees", and a low-emphasis break-glass to start anyway
+                (progressExits resumes once fees are added). */}
+            {exitFeeGated && (
+              <View style={{ marginTop: 12, marginHorizontal: 24, padding: 12, borderRadius: 10, backgroundColor: 'rgba(255, 200, 80, 0.06)', borderWidth: 1, borderColor: 'rgba(255, 200, 80, 0.30)' }}>
+                <Text bold style={{ fontSize: 13, color: '#FFD54F', marginBottom: 6 }}>
+                  Fund exit fees first
+                </Text>
+                <Text style={{ fontSize: 12, color: '#CCC', lineHeight: 17 }}>
+                  Emergency Exit pays Bitcoin miner fees from a separate on-chain wallet that holds {onchainReserveSats.toLocaleString()} sats. Add about {exitFeeShortfallSats.toLocaleString()} sats more so the exit can broadcast and confirm. Without it the exit will stall.
+                </Text>
+                <TouchableOpacity
+                  onPress={openExitFunding}
+                  style={{ marginTop: 10, paddingVertical: 10, borderRadius: 8, alignItems: 'center', backgroundColor: '#FFD54F' }}
+                >
+                  <Text bold style={{ fontSize: 13, color: '#1C1C1C' }}>
+                    Fund exit fees
+                  </Text>
+                </TouchableOpacity>
+                {/* Break-glass only when they actually have SOME on-chain fee
+                    money. With 0 sats the exit can't broadcast anything, so
+                    starting it is pointless: hide the escape hatch entirely. */}
+                {onchainReserveSats > 0 && (
+                  <TouchableOpacity
+                    onPress={() => setExitPickerOpen(true)}
+                    hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+                    style={{ marginTop: 10, alignItems: 'center' }}
+                  >
+                    <Text style={{ fontSize: 12, color: '#888', textDecorationLine: 'underline' }}>
+                      Start exit anyway
+                    </Text>
+                  </TouchableOpacity>
+                )}
+              </View>
+            )}
+
+            {/* Funded confirmation: the on-chain fee wallet now covers the
+                reserve, so the button is unlocked. Confirm the sats are set
+                aside and, critically, that the exit is an EARLY tool: it must
+                be started at least a day before a capsule expires, never as a
+                last-minute rescue (the exit txs must confirm on-chain before
+                the expiry, which takes time). */}
+            {exitFeeFunded && (
+              <View style={{ marginTop: 12, marginHorizontal: 24, padding: 12, borderRadius: 10, backgroundColor: 'rgba(35, 196, 127, 0.07)', borderWidth: 1, borderColor: 'rgba(35, 196, 127, 0.35)' }}>
+                <Text bold style={{ fontSize: 13, color: colors.green, marginBottom: 6 }}>
+                  Exit fees ready
+                </Text>
+                <Text style={{ fontSize: 12, color: '#CCC', lineHeight: 17 }}>
+                  {onchainReserveSats.toLocaleString()} sats are reserved on-chain to pay Emergency Exit fees. Start the exit at least 1 day before your soonest capsule expires. It unrolls on-chain and needs time to confirm, so it is not a last-minute rescue.
+                </Text>
+                {reserveBelowRecommended && (
+                  <Text style={{ fontSize: 11, color: '#FFD54F', marginTop: 8, lineHeight: 15 }}>
+                    You reserved less than the recommended {(recommendedReserveSats ?? 0).toLocaleString()} sats. A fee spike could stall the exit.
+                  </Text>
+                )}
+                <View style={{ flexDirection: 'row', marginTop: 12 }}>
+                  <TouchableOpacity
+                    onPress={openExitFunding}
+                    style={{ flex: 1, paddingVertical: 9, borderRadius: 8, alignItems: 'center', borderWidth: 1, borderColor: colors.green, marginRight: 8 }}
+                  >
+                    <Text bold style={{ fontSize: 12, color: colors.green }}>Add more</Text>
+                  </TouchableOpacity>
+                  <TouchableOpacity
+                    onPress={doReleaseReserve}
+                    style={{ flex: 1, paddingVertical: 9, borderRadius: 8, alignItems: 'center', borderWidth: 1, borderColor: '#888' }}
+                  >
+                    <Text bold style={{ fontSize: 12, color: '#AAA' }}>Release</Text>
+                  </TouchableOpacity>
+                </View>
+              </View>
+            )}
 
             {/* Caption row: short summary + circular "?" toggle that
                 expands an inline note explaining all the cases where
@@ -1964,6 +2271,151 @@ export function ArkSettingsBody({ view = 'backup' }: { view?: 'backup' | 'action
                 style={{ marginTop: 14, paddingVertical: 10, alignItems: 'center' }}
               >
                 <Text bold style={{ fontSize: 14, color: '#AAA' }}>Cancel</Text>
+              </TouchableOpacity>
+            </View>
+          </View>
+        </Modal>
+
+        {/* Fund-exit-fees modal. Tops up the on-chain (BDK) wallet that pays
+            the unilateral-exit CPFP fees. Two paths:
+              Receive Bitcoin (primary, ASP-independent): deposit external BTC
+                to the on-chain address; the armed reserve keeps it on-chain
+                (sync.ts won't board it away) and the gate unlocks on confirm.
+              Convert from balance (secondary, precautionary): cooperative
+                offboard from Ark. Needs the ASP, so disabled when unreachable;
+                do it ahead of time, not as an at-outage rescue. */}
+        <Modal
+          visible={exitFundingOpen}
+          transparent
+          animationType="fade"
+          onRequestClose={() => !fundingBusy && setExitFundingOpen(false)}
+        >
+          <View style={{ flex: 1, backgroundColor: 'rgba(0,0,0,0.7)', justifyContent: 'center', paddingHorizontal: 24 }}>
+            <View style={{ backgroundColor: '#1a1a1a', borderRadius: 14, padding: 18, borderWidth: 1, borderColor: colors.ark?.light ?? colors.pink.default }}>
+              <Text bold style={{ fontSize: 17, color: '#FFF', marginBottom: 4 }}>
+                Fund exit fees
+              </Text>
+              <Text style={{ fontSize: 12, color: '#AAA', marginBottom: 12, lineHeight: 17 }}>
+                Emergency Exit needs on-chain sats to pay Bitcoin miner fees. On-chain now: {onchainReserveSats.toLocaleString()} of {reserveTargetSats.toLocaleString()} sats reserved.
+              </Text>
+
+              {/* Editable reserve target: hold more (bigger fee-spike buffer) or
+                  less. Applied on blur; auto-board keeps exactly this much
+                  on-chain and boards any surplus into the Ark balance. */}
+              <Text style={{ fontSize: 12, color: '#FFF', marginBottom: 6 }}>Reserve for fees (sats)</Text>
+              <TextInput
+                value={reserveTargetInput}
+                onChangeText={(t) => setReserveTargetInput(t.replace(/[^0-9]/g, ''))}
+                onEndEditing={applyReserveTarget}
+                keyboardType="number-pad"
+                placeholder={String(recommendedReserveSats ?? 0)}
+                placeholderTextColor="#666"
+                editable={!fundingBusy}
+                style={{ color: '#FFF', borderWidth: 1, borderColor: '#444', borderRadius: 8, padding: 10, fontSize: 14, marginBottom: 4 }}
+              />
+              <Text style={{ fontSize: 11, color: '#777', marginBottom: 14, lineHeight: 15 }}>
+                Recommended {(recommendedReserveSats ?? 0).toLocaleString()} sats. We keep this much on-chain; anything above it boards into your Ark balance.
+              </Text>
+
+              {/* Tab switch */}
+              <View style={{ flexDirection: 'row', marginBottom: 14, borderRadius: 10, backgroundColor: '#222', padding: 3 }}>
+                {(['receive', 'convert'] as const).map((tab) => {
+                  const active = fundingTab === tab;
+                  return (
+                    <TouchableOpacity
+                      key={tab}
+                      onPress={() => setFundingTab(tab)}
+                      style={{ flex: 1, paddingVertical: 8, borderRadius: 8, alignItems: 'center', backgroundColor: active ? (colors.ark?.light ?? colors.pink.default) : 'transparent' }}
+                    >
+                      <Text bold style={{ fontSize: 12, color: active ? '#1C1C1C' : '#AAA' }}>
+                        {tab === 'receive' ? 'Receive Bitcoin' : 'Convert from balance'}
+                      </Text>
+                    </TouchableOpacity>
+                  );
+                })}
+              </View>
+
+              {fundingTab === 'receive' && (
+                <>
+                  <Text style={{ fontSize: 12, color: '#CCC', marginBottom: 12, lineHeight: 17 }}>
+                    Send at least {exitFeeShortfallSats.toLocaleString()} sats to this address. It stays on-chain to pay exit fees (it will not be moved into Ark).
+                  </Text>
+                  {onchainFundAddr ? (
+                    <>
+                      <View style={{ alignSelf: 'center', backgroundColor: 'white', padding: 10, borderRadius: 10, marginBottom: 12 }}>
+                        <QRCode value={onchainFundAddr} size={150} color="black" backgroundColor="white" />
+                      </View>
+                      <TouchableOpacity
+                        onPress={() => {
+                          if (onchainFundAddr) {
+                            Clipboard.setString(onchainFundAddr);
+                            SimpleToast.show('Address copied', SimpleToast.SHORT);
+                          }
+                        }}
+                        activeOpacity={0.7}
+                        style={{ flexDirection: 'row', alignItems: 'center', paddingHorizontal: 12, paddingVertical: 10, backgroundColor: 'rgba(255,255,255,0.08)', borderRadius: 10, marginBottom: 8 }}
+                      >
+                        <Text style={{ fontSize: 12, color: '#CCC', flex: 1, fontFamily: 'monospace' }} numberOfLines={1}>
+                          {onchainFundAddr}
+                        </Text>
+                        <Image source={Copy} style={{ width: 20, height: 16, marginLeft: 8, tintColor: '#aaa' }} resizeMode="contain" />
+                      </TouchableOpacity>
+                      <Text style={{ fontSize: 11, color: '#777', lineHeight: 15 }}>
+                        Emergency Exit unlocks automatically once the deposit confirms on-chain.
+                      </Text>
+                    </>
+                  ) : (
+                    <ActivityIndicator color={colors.ark?.light ?? colors.pink.default} style={{ marginVertical: 24 }} />
+                  )}
+                </>
+              )}
+
+              {fundingTab === 'convert' && (
+                <>
+                  <Text style={{ fontSize: 12, color: '#CCC', marginBottom: 10, lineHeight: 17 }}>
+                    Move sats from your Ark balance to the on-chain fee wallet. This uses the Ark server, so do it ahead of time. It will not work if the server is down.
+                  </Text>
+                  {aspReachable === false && (
+                    <View style={{ padding: 10, borderRadius: 8, backgroundColor: 'rgba(232, 92, 90, 0.08)', borderWidth: 1, borderColor: colors.redLight, marginBottom: 10 }}>
+                      <Text style={{ fontSize: 12, color: '#FFF' }}>
+                        Ark server unreachable. Use Receive Bitcoin instead.
+                      </Text>
+                    </View>
+                  )}
+                  <Text style={{ fontSize: 12, color: '#FFF', marginBottom: 6 }}>Amount (sats)</Text>
+                  <TextInput
+                    value={convertAmount}
+                    onChangeText={(t) => setConvertAmount(t.replace(/[^0-9]/g, ''))}
+                    keyboardType="number-pad"
+                    placeholder="0"
+                    placeholderTextColor="#666"
+                    editable={aspReachable !== false && !fundingBusy}
+                    style={{ color: '#FFF', borderWidth: 1, borderColor: '#444', borderRadius: 8, padding: 10, fontSize: 14 }}
+                  />
+                  {convertEst && (
+                    <Text style={{ fontSize: 12, color: '#AAA', marginTop: 8, lineHeight: 17 }}>
+                      About {convertEst.netLandingSats.toLocaleString()} sats will land on-chain after a {convertEst.feeSats.toLocaleString()} sat fee.
+                    </Text>
+                  )}
+                  <TouchableOpacity
+                    onPress={doConvertToExitFees}
+                    disabled={fundingBusy || aspReachable === false || !convertEst}
+                    style={{ marginTop: 14, paddingVertical: 12, borderRadius: 10, alignItems: 'center', backgroundColor: (fundingBusy || aspReachable === false || !convertEst) ? '#222' : (colors.ark?.light ?? colors.pink.default) }}
+                  >
+                    <Text bold style={{ fontSize: 13, color: (fundingBusy || aspReachable === false || !convertEst) ? '#666' : '#000' }}>
+                      {fundingBusy ? 'Converting…' : 'Convert to exit fees'}
+                    </Text>
+                  </TouchableOpacity>
+                </>
+              )}
+
+              <TouchableOpacity
+                onPress={() => !fundingBusy && setExitFundingOpen(false)}
+                style={{ marginTop: 14, paddingVertical: 10, alignItems: 'center' }}
+              >
+                <Text bold style={{ fontSize: 13, color: '#AAA' }}>
+                  Close
+                </Text>
               </TouchableOpacity>
             </View>
           </View>

--- a/src/services/ark/backgroundNotifications.ts
+++ b/src/services/ark/backgroundNotifications.ts
@@ -299,6 +299,68 @@ const WARN_SCHEDULE: ReadonlyArray<{
     },
 ];
 
+// --- Stuck-refresh SWAP-OUT notifications -----------------------------------
+//
+// A separate notification category from the five refresh warnings above.
+// These fire ONLY when a refresh round is wedged (stuck past 2× the round
+// interval, per useArkSync) AND the Locked funds are near their pre-refresh
+// expiry. At that point telling the user to "tap to refresh" is wrong (the
+// refresh is what's stuck). Instead these say "move your funds out" and their
+// tap deep-links to ArkStuckCapsuleScreen (cancel the wedged round + swap to
+// another wallet), not the auto-refresh path.
+//
+// Product decision (2026-07-15): the 24h refresh warning stays as-is (a
+// freshly received arkoor VTXO legitimately has a 24-48h TTL, so refresh is
+// still the right first action there); only from 12h down does a stuck round
+// escalate to "swap out". So the schedule is 12h / 6h / 3h. The refresh 12h/6h
+// warnings are already cancelled the moment a VTXO goes Locked (it drops out
+// of the spendable set the scheduler reconciles against), so there is no
+// double-notification: these replace them for the stuck-and-locked window.
+type StuckSwapKind = 'swap12h' | 'swap6h' | 'swap3h';
+
+export const ARK_STUCK_SWAP_SOURCES = [
+    'ark-vtxo-stuck-swap12h',
+    'ark-vtxo-stuck-swap6h',
+    'ark-vtxo-stuck-swap3h',
+] as const;
+
+export type ArkStuckSwapSource = (typeof ARK_STUCK_SWAP_SOURCES)[number];
+
+export function isArkStuckSwapSource(s: unknown): s is ArkStuckSwapSource {
+    return typeof s === 'string'
+        && (ARK_STUCK_SWAP_SOURCES as readonly string[]).includes(s);
+}
+
+const STUCK_SWAP_SCHEDULE: ReadonlyArray<{
+    kind: StuckSwapKind;
+    source: ArkStuckSwapSource;
+    offsetMs: number;
+    label: string;
+    suffix: string;
+}> = [
+    {
+        kind: 'swap12h',
+        source: 'ark-vtxo-stuck-swap12h',
+        offsetMs: 12 * 60 * 60 * 1000,
+        label: '12 hours',
+        suffix: ' ⚠️',
+    },
+    {
+        kind: 'swap6h',
+        source: 'ark-vtxo-stuck-swap6h',
+        offsetMs: 6 * 60 * 60 * 1000,
+        label: '6 hours',
+        suffix: ' 🚨',
+    },
+    {
+        kind: 'swap3h',
+        source: 'ark-vtxo-stuck-swap3h',
+        offsetMs: 3 * 60 * 60 * 1000,
+        label: '3 hours',
+        suffix: ' 🚨',
+    },
+];
+
 /**
  * Hash a VTXO id + kind to a stable 31-bit signed integer.
  *
@@ -323,7 +385,7 @@ const WARN_SCHEDULE: ReadonlyArray<{
  * {@link cancelVtxoExpiryWarnings} so users don't get phantom alerts about
  * funds that already moved.
  */
-function notificationIdFor(vtxoId: string, kind: WarnKind): string {
+function notificationIdFor(vtxoId: string, kind: WarnKind | StuckSwapKind): string {
     let h = 2166136261;
     const tagged = `${kind}:${vtxoId}`;
     for (let i = 0; i < tagged.length; i++) {
@@ -411,6 +473,52 @@ export function cancelVtxoExpiryWarnings(vtxoId: string): void {
     }
 }
 
+/**
+ * Schedule the 12h/6h/3h "move your funds out" alarms for a Locked VTXO whose
+ * refresh round is stuck. `expiryAtMs` is the VTXO's pre-refresh expiry (the
+ * deadline the stuck round failed to extend). Mirrors
+ * {@link scheduleVtxoExpiryWarnings}: gated on the reminders toggle, idempotent
+ * by id, skips levels already past. Cancellation on state change is the
+ * caller's job via {@link cancelVtxoStuckSwapWarnings}.
+ */
+export function scheduleVtxoStuckSwapWarnings(
+    vtxoId: string,
+    expiryAtMs: number,
+    satsAmount?: number,
+): void {
+    if (!useAuthStore.getState().arkBgRefreshEnabled) return;
+    ensureInit();
+    const now = Date.now();
+    const subject = fmtSatsSubject(satsAmount);
+    for (const w of STUCK_SWAP_SCHEDULE) {
+        const at = expiryAtMs - w.offsetMs;
+        if (at <= now) continue;
+        PushNotification.localNotificationSchedule({
+            id: notificationIdFor(vtxoId, w.kind),
+            channelId: CHANNEL_ID,
+            title: `Refresh stuck: move ${subject} out${w.suffix}`,
+            message: `${w.label} left before expiry. Tap to move your funds to another wallet.`,
+            date: new Date(at),
+            priority: 'high',
+            importance: 'high',
+            playSound: true,
+            soundName: 'default',
+            userInfo: { source: w.source, vtxoId },
+            allowWhileIdle: true,
+        });
+    }
+}
+
+export function cancelVtxoStuckSwapWarnings(vtxoId: string): void {
+    try {
+        for (const w of STUCK_SWAP_SCHEDULE) {
+            PushNotification.cancelLocalNotification(notificationIdFor(vtxoId, w.kind));
+        }
+    } catch (err) {
+        console.warn('[Ark notifications] cancelVtxoStuckSwapWarnings:', err);
+    }
+}
+
 export function notifyDustUneconomic(
     feeSats: number,
     totalSats: number,
@@ -488,5 +596,21 @@ export function notifyStuckRefresh(sats?: number): void {
         'Refresh stuck',
         `A capsule refresh got stuck${amount}. Open Cypher Box to recover it.`,
         'high',
+    );
+}
+
+/**
+ * Fire the stuck-refresh SWAP-OUT notification immediately, with the same
+ * content + source as the scheduled 12h warning so the tap deep-links to
+ * ArkStuckCapsuleScreen. Used by the in-app dev test trigger to exercise the
+ * notification path without waiting for a real stuck round near expiry.
+ */
+export function notifyStuckSwapNow(satsAmount?: number): void {
+    const subject = fmtSatsSubject(satsAmount);
+    fire(
+        `Refresh stuck: move ${subject} out ⚠️`,
+        '12 hours left before expiry. Tap to move your funds to another wallet.',
+        'high',
+        { source: 'ark-vtxo-stuck-swap12h' },
     );
 }

--- a/src/services/ark/exitFunding.ts
+++ b/src/services/ark/exitFunding.ts
@@ -1,0 +1,236 @@
+/**
+ * Exit-fee funding: size, gate, and top up the on-chain wallet that pays for
+ * a unilateral (emergency) exit.
+ *
+ * Why this exists: `progressExits(onchain, feeRate)` (see ./exit.ts) fee-bumps
+ * the exit-tree txs via CPFP, and it draws those fees from bark's SEPARATE
+ * on-chain (BDK) wallet, NOT from the user's Ark (VTXO) balance. For a
+ * Lightning-only user that on-chain wallet holds 0 sats, so an exit started
+ * today just stalls: `progressExits` retries every sync tick with nothing to
+ * broadcast. This module computes a recommended on-chain reserve, tells the UI
+ * whether it's funded, and offers the cooperative-offboard ("convert") top-up.
+ * The receive top-up (external BTC to `getArkOnchainAddress()`) is the
+ * ASP-independent path and lives in the UI directly.
+ *
+ * Fee-source note: the reserve funds `progressExits` (CPFP) ONLY.
+ * `drainExits` (the final sweep to the user's address) takes no on-chain
+ * wallet (its fee comes off the swept output), so it is deliberately NOT part
+ * of this reserve.
+ */
+
+import { getArkOnchainAddress } from './receive';
+import { ensureArkWalletHandleReady } from './restore';
+import { getArkWalletHandle } from './walletHandle';
+
+// --- Tunable sizing constants ----------------------------------------------
+//
+// The reserve is grounded in the SDK's own per-VTXO exit-cost data
+// (`Vtxo.exitTxWeightWu` = weight of the full unilateral exit tx chain, and
+// `Vtxo.exitDepth` = number of levels in that chain), so it tracks real exit
+// cost rather than a blind guess. The multipliers add headroom for the
+// multi-block window an exit spans (a fee spike mid-exit is its weak spot, and
+// per Bark's Peter you want runway to "refill the onchain wallet if you run
+// out"). All values are intentionally conservative: over-reserving is
+// harmless (the extra sats stay the user's own on-chain, and the auto-board
+// pipeline boards any excess above the reserve back into Ark later), while
+// under-reserving stalls the exit.
+
+/** Per exit-tree level: the CPFP child (anchor input + funding input + change)
+ *  that bumps that level. Upper-bounded; matches RECOVER_EST_VSIZE in
+ *  ./recoverOnchainBoard.ts. Applied `exitDepth` times per VTXO. */
+const CPFP_CHILD_VB = 150;
+/** Headroom multiplier over the current fee rate, for a fee spike during the
+ *  (multi-block) exit window. */
+const SPIKE_MULT = 2.0;
+/** Lower bound whenever there is anything to exit, so a low fee rate (or a
+ *  runtime `exitTxWeightWu` of 0) still reserves enough for at least one CPFP
+ *  child at a moderate rate. Kept below the 50k board minimum so it doesn't
+ *  over-hoard on-chain. */
+const RESERVE_FLOOR_SATS = 10_000;
+/** Fallback per-VTXO vsize used only if the SDK returns `exitTxWeightWu === 0`
+ *  at runtime (the type says it's populated; guard anyway). */
+const FALLBACK_VB_PER_VTXO = 200;
+/** Fee-rate fallback (sat/vB) when the mempool fetch fails. Deliberately not
+ *  tiny, since an emergency exit may run during congestion. */
+const RESERVE_FEE_FALLBACK_RATE = 20;
+
+export type ExitFeeReserve = {
+    /** Recommended sats to hold on-chain to fund the exit. 0 when nothing is
+     *  exitable (so a nothing-to-exit wallet is never gated). */
+    recommendedSats: number;
+    /** Count of VTXOs the reserve was sized over. */
+    vtxoCount: number;
+    /** Fee rate (sat/vB) the recommendation was computed at. */
+    feeRateSatPerVb: number;
+    /** Summed exit vsize across the exitable VTXOs (pre-multiplier). */
+    totalExitVb: number;
+};
+
+export type ExitFeeConvertEstimate = {
+    /** What the user asked to move from Ark. */
+    grossSats: number;
+    /** Cooperative-offboard + on-chain fee taken off the top. */
+    feeSats: number;
+    /** What actually lands in the on-chain fee wallet (gross - fee). */
+    netLandingSats: number;
+};
+
+/**
+ * Current FAST on-chain fee rate (sat/vB) from mempool.space. Unlike the
+ * recovery path (which deliberately targets ~1h since recovery isn't urgent),
+ * an exit may need to confirm during congestion, so we use `fastestFee`.
+ * Always resolves, falling back to a constant on any error/timeout. Uses
+ * mempool.space rather than the configured esplora (blockstream), which the
+ * codebase repeatedly notes bot-blocks bark's client.
+ */
+export async function fetchFastFeeRateSatPerVb(): Promise<number> {
+    try {
+        const controller = new AbortController();
+        const t = setTimeout(() => controller.abort(), 4000);
+        const res = await fetch('https://mempool.space/api/v1/fees/recommended', {
+            signal: controller.signal,
+        });
+        clearTimeout(t);
+        if (!res.ok) return RESERVE_FEE_FALLBACK_RATE;
+        const rec = await res.json();
+        const raw = Number(rec?.fastestFee);
+        if (!isFinite(raw) || raw <= 0) return RESERVE_FEE_FALLBACK_RATE;
+        return Math.max(1, Math.ceil(raw));
+    } catch {
+        return RESERVE_FEE_FALLBACK_RATE;
+    }
+}
+
+/**
+ * Compute the recommended on-chain fee reserve for a full-wallet exit.
+ *
+ * Reads `handle.allVtxos()` fresh (the store's `ArkVtxoView` drops
+ * `exitTxWeightWu` / `exitDepth`, so the cached VTXO list can't be reused).
+ * (allVtxos is a JS-thread-blocking UniFFI call; call this off the render
+ * path.) Filters to non-spent VTXOs, mirroring the wallet-exit set that
+ * `startExitForEntireWallet` marks.
+ *
+ * Returns `recommendedSats: 0` when the wallet handle is unset or there is
+ * nothing exitable.
+ */
+export async function computeExitFeeReserveSats(): Promise<ExitFeeReserve> {
+    const empty: ExitFeeReserve = {
+        recommendedSats: 0,
+        vtxoCount: 0,
+        feeRateSatPerVb: 0,
+        totalExitVb: 0,
+    };
+
+    const handle = getArkWalletHandle();
+    if (!handle) return empty;
+
+    let vtxos;
+    try {
+        vtxos = await handle.allVtxos();
+    } catch (err) {
+        if (__DEV__) console.warn('[Ark exit-funding] allVtxos threw:', err);
+        return empty;
+    }
+
+    const exitable = (vtxos ?? []).filter(
+        (v) => String(v.state).toLowerCase() !== 'spent',
+    );
+    if (exitable.length === 0) return empty;
+
+    let totalExitVb = 0;
+    for (const v of exitable) {
+        const chainVb = Math.ceil(Number(v.exitTxWeightWu ?? 0n) / 4);
+        const perVtxoVb =
+            Math.max(chainVb, FALLBACK_VB_PER_VTXO) +
+            Math.max(0, Number(v.exitDepth ?? 0)) * CPFP_CHILD_VB;
+        totalExitVb += perVtxoVb;
+    }
+
+    const feeRateSatPerVb = await fetchFastFeeRateSatPerVb();
+    const computed = Math.ceil(totalExitVb * feeRateSatPerVb * SPIKE_MULT);
+    const recommendedSats = Math.max(RESERVE_FLOOR_SATS, computed);
+
+    if (__DEV__) {
+        console.log(
+            '[Ark exit-funding] reserve:',
+            recommendedSats, 'sats over', exitable.length, 'vtxos;',
+            'totalExitVb=', totalExitVb,
+            'feeRate=', feeRateSatPerVb, 'sat/vB; spikeMult=', SPIKE_MULT,
+        );
+    }
+
+    return {
+        recommendedSats,
+        vtxoCount: exitable.length,
+        feeRateSatPerVb,
+        totalExitVb,
+    };
+}
+
+/**
+ * Is the Ark server reachable right now? The "convert" top-up is a cooperative
+ * offboard that needs the ASP, so the UI disables it when this is false and
+ * steers the user to the receive (external BTC) path instead. `arkInfo()` is an
+ * ASP round-trip (mirrors fetchArkMinBoardSats in ./refresh.ts). Never throws.
+ */
+export async function probeAspReachable(): Promise<boolean> {
+    const handle = getArkWalletHandle();
+    if (!handle) return false;
+    try {
+        const info = await handle.arkInfo();
+        return !!info;
+    } catch (err) {
+        if (__DEV__) console.warn('[Ark exit-funding] arkInfo probe threw:', err);
+        return false;
+    }
+}
+
+/**
+ * Estimate a "convert" top-up: move `amountSats` from the Ark balance to the
+ * on-chain fee wallet via a cooperative offboard (`sendOnchain` to the wallet's
+ * own on-chain address). Sizes by NET landing so the UI can ensure the amount
+ * that actually reaches the fee wallet covers the shortfall (the offboard +
+ * on-chain fee come off the top).
+ */
+export async function estimateExitFeeConvert(
+    amountSats: number,
+): Promise<ExitFeeConvertEstimate> {
+    if (!Number.isFinite(amountSats) || amountSats <= 0) {
+        throw new Error('Invalid amount');
+    }
+    const handle = await ensureArkWalletHandleReady();
+    const address = await getArkOnchainAddress();
+    const fe = await handle.estimateSendOnchainFee(address, BigInt(Math.floor(amountSats)));
+    return {
+        grossSats: Number(fe.grossAmountSats),
+        feeSats: Number(fe.feeSats),
+        netLandingSats: Number(fe.netAmountSats),
+    };
+}
+
+/**
+ * Execute a "convert" top-up: cooperative offboard of `amountSats` from Ark to
+ * the on-chain fee wallet. Returns the offboard txid. Caller must ARM the
+ * reserve (setArkExitFeeReserveSats) BEFORE calling, or the offboarded sats get
+ * boarded straight back into a VTXO on the next sync tick.
+ *
+ * Precautionary only: this needs the ASP, so it cannot rescue an exit during an
+ * ASP outage. The receive (external BTC) path is the ASP-independent one.
+ */
+export async function convertToExitFees(
+    amountSats: number,
+): Promise<{ txid: string; grossSats: number }> {
+    if (!Number.isFinite(amountSats) || amountSats <= 0) {
+        throw new Error('Invalid amount');
+    }
+    const handle = await ensureArkWalletHandleReady();
+    const address = await getArkOnchainAddress();
+    const txid = await handle.sendOnchain(address, BigInt(Math.floor(amountSats)));
+    if (__DEV__) {
+        console.log(
+            '[Ark exit-funding] convert offboard broadcast',
+            amountSats, 'sats -> on-chain fee wallet; txid=', txid,
+        );
+    }
+    return { txid, grossSats: amountSats };
+}

--- a/src/services/ark/index.ts
+++ b/src/services/ark/index.ts
@@ -152,6 +152,14 @@ export {
     startArkEmergencyExit,
     syncArkExits,
 } from './exit';
+export {
+    computeExitFeeReserveSats,
+    convertToExitFees,
+    estimateExitFeeConvert,
+    fetchFastFeeRateSatPerVb,
+    probeAspReachable,
+} from './exitFunding';
+export type { ExitFeeReserve, ExitFeeConvertEstimate } from './exitFunding';
 export type { ArkRefreshFeeView, ArkRefreshResult } from './refresh';
 
 export {

--- a/src/services/ark/index.ts
+++ b/src/services/ark/index.ts
@@ -152,6 +152,8 @@ export {
     startArkEmergencyExit,
     syncArkExits,
 } from './exit';
+export { estimateArkOffboardFee, offboardArkVtxos } from './offboard';
+export type { ArkOffboardFeeView } from './offboard';
 export type { ArkRefreshFeeView, ArkRefreshResult } from './refresh';
 
 export {
@@ -176,6 +178,9 @@ export {
     areBgNotificationsEnabled,
     scheduleVtxoExpiryWarnings,
     cancelVtxoExpiryWarnings,
+    scheduleVtxoStuckSwapWarnings,
+    cancelVtxoStuckSwapWarnings,
+    notifyStuckSwapNow,
 } from './backgroundNotifications';
 
 export { registerArkNotificationTapHandler } from './notificationHandler';

--- a/src/services/ark/notificationHandler.ts
+++ b/src/services/ark/notificationHandler.ts
@@ -5,7 +5,11 @@ import SimpleToast from 'react-native-simple-toast';
 import useAuthStore from '@Cypher/stores/authStore';
 
 import { navigationRef } from '../../../NavigationService';
-import { isArkCapsuleTapSource, isArkExpiryWarningSource } from './backgroundNotifications';
+import {
+    isArkCapsuleTapSource,
+    isArkExpiryWarningSource,
+    isArkStuckSwapSource,
+} from './backgroundNotifications';
 
 /**
  * Notification-tap routing for the Ark capsule notifications: the five
@@ -73,6 +77,29 @@ async function dispatchArkCapsuleTap(autoRefresh: boolean): Promise<void> {
 }
 
 /**
+ * Deep-link a stuck-refresh "move your funds out" notification tap to
+ * ArkStuckCapsuleScreen. Unlike the expiry-warning taps, this does NOT arm
+ * auto-refresh, since refreshing is exactly what's stuck. The screen reads the
+ * live `arkRefreshStuck` state from the store (cancel + swap-out actions),
+ * so we pass only the vtxoId for context. Same cold-start nav-ready poll as
+ * dispatchArkCapsuleTap.
+ */
+async function dispatchArkStuckSwapTap(vtxoId: unknown): Promise<void> {
+    const wallet = useAuthStore.getState().arkWallet;
+    if (!wallet) return;
+
+    const start = Date.now();
+    while (!navigationRef.isReady() && Date.now() - start < NAV_WAIT_MS) {
+        await new Promise<void>(resolve => setTimeout(resolve, 100));
+    }
+    if (!navigationRef.isReady()) return;
+
+    navigationRef.current?.navigate('ArkStuckCapsuleScreen', {
+        vtxoId: typeof vtxoId === 'string' ? vtxoId : undefined,
+    });
+}
+
+/**
  * Shared tap routing, callable from ANY PushNotification.configure
  * onNotification. react-native-push-notification only honors the LAST
  * configure() call, and blue_modules/notifications.js re-configures when
@@ -84,6 +111,17 @@ async function dispatchArkCapsuleTap(autoRefresh: boolean): Promise<void> {
  */
 export function handleArkNotificationTap(notification: any): boolean {
     const data = (notification && (notification.data || notification.userInfo)) || {};
+    // Stuck-refresh swap-out taps route to ArkStuckCapsuleScreen instead of
+    // the Capsules tab + auto-refresh. Checked first because these sources
+    // are deliberately NOT in isArkCapsuleTapSource (refreshing is stuck).
+    if (
+        notification &&
+        notification.userInteraction === true &&
+        isArkStuckSwapSource(data.source)
+    ) {
+        void dispatchArkStuckSwapTap(data.vtxoId);
+        return true;
+    }
     if (
         notification &&
         notification.userInteraction === true &&

--- a/src/services/ark/offboard.ts
+++ b/src/services/ark/offboard.ts
@@ -1,0 +1,56 @@
+import { getArkWalletHandle } from './walletHandle';
+
+/**
+ * Cooperative on-chain offboard of SPECIFIC VTXOs (coin control).
+ *
+ * Unlike `sendOnchain(address, amount)` (amount-based, SDK auto-selects inputs),
+ * `offboardVtxos(vtxoIds, address)` moves exactly the VTXOs we name on-chain to
+ * `address`. Used by the stuck-refresh rescue screen to move precisely the
+ * near-expiry capsules to a Hot / Cold vault or an external Bitcoin address.
+ * The offboard fee is taken from the moved amount (see `estimateArkOffboardFee`).
+ *
+ * Requires the ASP to cooperate on the offboard (same as any non-exit path); if
+ * the ASP is fully down the caller should fall back to a Lightning swap or the
+ * unilateral exit. Not for the "server is malicious" case (that is exit.ts).
+ */
+function requireHandle() {
+    const handle = getArkWalletHandle();
+    if (!handle) throw new Error('Ark wallet not open, cannot offboard');
+    return handle;
+}
+
+export type ArkOffboardFeeView = {
+    /** Offboard fee in sats (taken out of the moved amount). */
+    feeSats: number;
+    /** Amount that lands on-chain after the fee. */
+    netSats: number;
+    /** Total value of the VTXOs being offboarded (net + fee). */
+    grossSats: number;
+    /** The VTXO ids the SDK will spend for this offboard. */
+    vtxosSpent: string[];
+};
+
+export async function estimateArkOffboardFee(
+    address: string,
+    vtxoIds: string[],
+): Promise<ArkOffboardFeeView> {
+    const handle = requireHandle();
+    const est = await handle.estimateOffboardFee(address.trim(), vtxoIds);
+    return {
+        feeSats: Number(est.feeSats),
+        netSats: Number(est.netAmountSats),
+        grossSats: Number(est.grossAmountSats),
+        vtxosSpent: est.vtxosSpent,
+    };
+}
+
+/**
+ * Offboard the named VTXOs on-chain to `address`. Returns the broadcast txid.
+ */
+export async function offboardArkVtxos(
+    vtxoIds: string[],
+    address: string,
+): Promise<string> {
+    const handle = requireHandle();
+    return await handle.offboardVtxos(vtxoIds, address.trim());
+}

--- a/src/services/ark/sync.ts
+++ b/src/services/ark/sync.ts
@@ -1,4 +1,14 @@
+import useAuthStore from '@Cypher/stores/authStore';
+
 import { getArkOnchainHandle, getArkWalletHandle, rotateArkOnchainEsplora, setLastOnchainBalanceSats } from './walletHandle';
+
+// Flat board-fee headroom (sats) subtracted from the boardable surplus when an
+// exit-fee reserve is armed, so boardAmount's own fee can't erode the reserve
+// regardless of whether it deducts fee from the boarded amount or the leftover.
+const BOARD_FEE_HEADROOM_SATS = 1500;
+// Server board minimum (ark.second.tech). A surplus below this can never board,
+// so we hold it on-chain rather than retry-storming boardAmount against it.
+const MIN_BOARD_SATS = 50_000;
 
 /**
  * Pull round finalizations, incoming payments, and blockchain state from
@@ -74,7 +84,52 @@ export async function syncArkWallet(): Promise<boolean> {
             // second clause prevents double-firing while a previous board
             // is mid-round and bark has not yet observed the input
             // consumption back from BDK's scanner.
-            if (onchainBal.confirmedSats > 0n && arkBal.pendingBoardSats === 0n) {
+            //
+            // Reserve/exit awareness (fund-safety): the unilateral-exit CPFP
+            // fees are paid from THIS on-chain wallet. Two rules keep that fee
+            // money from being auto-boarded away:
+            //   1. While an exit is in progress, board NOTHING, since every VTXO is
+            //      already in exit state and the on-chain balance is fee money.
+            //      The guard lives HERE (not only in useArkSync's exit branch)
+            //      because ArkCapsules calls syncArkWallet() directly on a
+            //      stuck-round cancel, unguarded by the exit-in-progress flag.
+            //   2. When the user has armed an exit-fee reserve, keep that many
+            //      sats on-chain: board only the EXCESS above it (boardAmount),
+            //      never boardAll. reserveSats === 0 (every user who hasn't
+            //      touched the exit-funding flow) keeps the exact old boardAll
+            //      behavior.
+            const authState = useAuthStore.getState();
+            const reserveSats = authState.arkExitFeeReserveSats ?? 0;
+            const canBoard =
+                !authState.arkExitInProgress &&
+                onchainBal.confirmedSats > 0n &&
+                arkBal.pendingBoardSats === 0n;
+            if (canBoard && reserveSats > 0) {
+                // Board only the surplus above the reserve. Subtract a flat
+                // board-fee headroom so boardAmount's own fee can't dip the
+                // leftover below the reserve. Only board when the surplus
+                // clears the server board minimum (a smaller surplus can never
+                // board and would retry-storm), otherwise hold it on-chain.
+                const confirmed = Number(onchainBal.confirmedSats);
+                const excess = confirmed - reserveSats - BOARD_FEE_HEADROOM_SATS;
+                if (excess >= MIN_BOARD_SATS) {
+                    console.log(
+                        '[Ark sync] auto-board (reserve armed): boarding surplus',
+                        excess, 'sats; keeping', reserveSats, 'on-chain for exit fees',
+                    );
+                    try {
+                        await handle.boardAmount(onchain, BigInt(excess));
+                        console.log('[Ark sync] auto-board: boardAmount initiated');
+                    } catch (boardErr) {
+                        console.warn('[Ark sync] auto-board: boardAmount failed:', boardErr);
+                    }
+                } else if (__DEV__) {
+                    console.log(
+                        '[Ark sync] auto-board held: surplus', excess,
+                        'below board minimum; keeping funds on-chain for exit fees',
+                    );
+                }
+            } else if (canBoard) {
                 console.log(
                     '[Ark sync] auto-board: detected',
                     String(onchainBal.confirmedSats),
@@ -86,6 +141,8 @@ export async function syncArkWallet(): Promise<boolean> {
                 } catch (boardErr) {
                     console.warn('[Ark sync] auto-board: boardAll failed:', boardErr);
                 }
+            } else if (authState.arkExitInProgress && onchainBal.confirmedSats > 0n && __DEV__) {
+                console.log('[Ark sync] auto-board skipped: exit in progress, holding on-chain funds for exit fees');
             }
 
             // Progress any pending boards through their phases. No-op when

--- a/src/stores/authStore.ts
+++ b/src/stores/authStore.ts
@@ -209,6 +209,17 @@ export type AuthStateType = {
      * (don't auto-claim on a stale exit-in-progress flag from a crash).
      */
     arkExitStartedAt: number | null;
+    /**
+     * Armed on-chain fee reserve, in sats. The bark on-chain (BDK) wallet pays
+     * the unilateral-exit CPFP fees; this is the amount the user has committed
+     * to keep on-chain for that purpose. While > 0 the auto-board pipeline
+     * (`sync.ts`) leaves this many sats on-chain instead of boarding every
+     * confirmed deposit straight back into a VTXO, otherwise funds sent to
+     * cover exit fees would be boarded away the moment they land. 0 = no
+     * reserve armed (default; auto-board behaves exactly as before). Set when
+     * the user opens the "Fund exit fees" flow; reset on wallet teardown.
+     */
+    arkExitFeeReserveSats: number;
     arkUseHotVaultSeed: boolean;
     withdrawArkThreshold: any | null;
     reserveArkAmount: number;
@@ -229,6 +240,7 @@ export type AuthStateType = {
     setArkExitInProgress: (state: boolean) => void;
     setArkExitDestinationAddress: (state: string | null) => void;
     setArkExitStartedAt: (state: number | null) => void;
+    setArkExitFeeReserveSats: (state: number) => void;
     setArkUseHotVaultSeed: (state: boolean) => void;
     setWithdrawArkThreshold: (state: any) => void;
     setReserveArkAmount: (state: number) => void;
@@ -434,6 +446,7 @@ const createAuthStore = (
     arkExitInProgress: false,
     arkExitDestinationAddress: null,
     arkExitStartedAt: null,
+    arkExitFeeReserveSats: 0,
     arkUseHotVaultSeed: false,
     withdrawArkThreshold: 500000,
     reserveArkAmount: 100000,
@@ -505,6 +518,7 @@ const createAuthStore = (
     setArkExitInProgress: (state: boolean) => set({ arkExitInProgress: state }),
     setArkExitDestinationAddress: (state: string | null) => set({ arkExitDestinationAddress: state }),
     setArkExitStartedAt: (state: number | null) => set({ arkExitStartedAt: state }),
+    setArkExitFeeReserveSats: (state: number) => set({ arkExitFeeReserveSats: state }),
     setArkUseHotVaultSeed: (state: boolean) => set({ arkUseHotVaultSeed: state }),
     setWithdrawArkThreshold: (state: any) => set({ withdrawArkThreshold: state }),
     setReserveArkAmount: (state: number) => set({ reserveArkAmount: state }),
@@ -543,6 +557,7 @@ const createAuthStore = (
             arkExitInProgress: false,
             arkExitDestinationAddress: null,
             arkExitStartedAt: null,
+            arkExitFeeReserveSats: 0,
             arkUseHotVaultSeed: false,
             allBTCWallets: get().allBTCWallets.filter(wallet => wallet !== 'ARK'),
             // Keep thresholds — don't reset on logout

--- a/src/stores/authStore.ts
+++ b/src/stores/authStore.ts
@@ -26,6 +26,17 @@ export type ArkRefreshStuckInfo = {
     stuckSats: number;
     /** Chain tip at detection time — for "X blocks past expiry" messaging. */
     detectedAtTip: number;
+    /**
+     * True when the stuck round's Locked VTXOs are inside the swap-out
+     * window (12h of their pre-refresh expiry). Set by useArkSync alongside
+     * the stuck detection. Flips the recovery UX from "cancel & retry" to
+     * "move your funds out": the home-card banner, the Capsules banner, and
+     * the swap-out expiry notifications all route to ArkStuckCapsuleScreen
+     * instead of the in-place cancel-and-retry when this is true. Optional
+     * so state persisted before this field migrates cleanly (treated as
+     * false / not-near-expiry).
+     */
+    nearExpiry?: boolean;
 };
 
 export type AuthStateType = {
@@ -139,6 +150,18 @@ export type AuthStateType = {
      */
     arkScheduledExpiryNotifs: Record<string, number>;
     /**
+     * Map of `vtxoId → scheduled-for expiry epoch ms` for Locked VTXOs that
+     * have the stuck-refresh SWAP-OUT notifications (12h/6h/3h) queued via
+     * `scheduleVtxoStuckSwapWarnings`. Separate from
+     * `arkScheduledExpiryNotifs` (the refresh-flavoured warnings) because
+     * these fire only while a round is stuck AND the funds are near expiry,
+     * and their tap routes to ArkStuckCapsuleScreen ("move your funds out")
+     * rather than arming an auto-refresh. Persisted so the sync sweep doesn't
+     * re-schedule every tick; reconciled the same way (add when stuck+near,
+     * cancel when the VTXO unlocks / stops being stuck / stops being near).
+     */
+    arkScheduledStuckSwapNotifs: Record<string, number>;
+    /**
      * Version of the expiry-warning schedule reflected in the OS notification
      * queue. Bumped when the schedule changes (e.g. moving from 24h+6h to
      * 4d/2d/24h/12h/6h). On the first sync after upgrade, useArkSync compares
@@ -220,6 +243,7 @@ export type AuthStateType = {
     setArkRefreshStuck: (state: ArkRefreshStuckInfo | null) => void;
     setArkPendingRoundFirstSeen: (state: Record<string, number>) => void;
     setArkScheduledExpiryNotifs: (state: Record<string, number>) => void;
+    setArkScheduledStuckSwapNotifs: (state: Record<string, number>) => void;
     setArkExpiryNotifsScheduleVersion: (state: number) => void;
     setArkPendingLnReceives: (state: ArkLightningReceiveView[]) => void;
     setArkChainTipHeight: (state: number | null) => void;
@@ -425,6 +449,7 @@ const createAuthStore = (
     arkRefreshStuck: null,
     arkPendingRoundFirstSeen: {},
     arkScheduledExpiryNotifs: {},
+    arkScheduledStuckSwapNotifs: {},
     arkExpiryNotifsScheduleVersion: 0,
     arkPendingLnReceives: [],
     arkChainTipHeight: null,
@@ -496,6 +521,7 @@ const createAuthStore = (
     setArkRefreshStuck: (state: ArkRefreshStuckInfo | null) => set({ arkRefreshStuck: state }),
     setArkPendingRoundFirstSeen: (state: Record<string, number>) => set({ arkPendingRoundFirstSeen: state }),
     setArkScheduledExpiryNotifs: (state: Record<string, number>) => set({ arkScheduledExpiryNotifs: state }),
+    setArkScheduledStuckSwapNotifs: (state: Record<string, number>) => set({ arkScheduledStuckSwapNotifs: state }),
     setArkExpiryNotifsScheduleVersion: (state: number) => set({ arkExpiryNotifsScheduleVersion: state }),
     setArkPendingLnReceives: (state: ArkLightningReceiveView[]) => set({ arkPendingLnReceives: state }),
     setArkChainTipHeight: (state: number | null) => set({ arkChainTipHeight: state }),
@@ -533,7 +559,8 @@ const createAuthStore = (
             arkVtxos: [],
             arkRefreshStuck: null,
             arkPendingRoundFirstSeen: {},
-    arkScheduledExpiryNotifs: {},
+            arkScheduledExpiryNotifs: {},
+            arkScheduledStuckSwapNotifs: {},
             arkExpiryNotifsScheduleVersion: 0,
             arkPendingLnReceives: [],
             arkChainTipHeight: null,


### PR DESCRIPTION
## Release v0.1.4 (vc31)

Bundles two Ark fund-safety features.

### Emergency-exit fee-funding gate
Unilateral exit fee-bumps its exit-tree txs (CPFP) from a separate on-chain BDK wallet that a Lightning-only user never funds, so an unfunded exit silently stalls.
- Gates Emergency Exit behind a recommended fee reserve, sized from each VTXO's `exitTxWeightWu` at a fast fee rate with spike headroom.
- Funding flow: Receive (external BTC, ASP-independent) or Convert (cooperative offboard), with an editable reserve target, add-more and release.
- Reserve-aware, exit-aware auto-board keeps funded sats on-chain instead of boarding them into a capsule.
- Funded state confirms the reserve and warns that the exit is an early tool (start at least a day before expiry).
- Capsules: column header flips Refresh to Cancel while a round is in flight; a come-back banner shows a live per-round 3h countdown and flips to a stuck state with a cancel action.

### Stuck-refresh swap-out rescue
Included from `feat/ark-stuck-swap` (514690d): near-expiry stuck rounds route to a swap-out rescue screen with dedicated notifications.

### Version
`0.1.4`, iOS CFBundleVersion `16`, Android versionCode `31`.

### Verification
- `npm run unit`: 29 suites, 212 passed.
- Typecheck: no new errors over the `main` baseline.
- No em dashes, no AI attribution across the diff.

### Note for review
`ArkCapsules.tsx` was the only heavy overlap between the two feature sets. It auto-merged cleanly (both symbol sets present, line counts sum exactly), but the stuck-swap author should sanity-check that file.
