### PR TITLE
fix(ark): refresh consent, swap/create resilience, recovery UX

### DIFF
--- a/src/components/LockedInRefreshNotice.tsx
+++ b/src/components/LockedInRefreshNotice.tsx
@@ -1,0 +1,64 @@
+import React from 'react';
+import { TouchableOpacity, View } from 'react-native';
+
+import { Text } from '@Cypher/component-library';
+import { dispatchNavigate } from '@Cypher/helpers';
+import useAuthStore from '@Cypher/stores/authStore';
+
+/**
+ * Shown in the Ark send / withdraw / swap flows when the user can't spend
+ * because their funds are LOCKED in an in-flight refresh round. Instead of a
+ * dead-end "insufficient balance", it tells them the funds exist but are
+ * mid-refresh and routes them to the Capsules tab, where the refresh can be
+ * cancelled.
+ *
+ * We deliberately do NOT offer an inline "cancel to spend" here: cancelling a
+ * round can take up to ~an hour, so an inline button would read as instant and
+ * mislead. The Capsules screen owns cancel and communicates its timing.
+ *
+ * COPY IS A PLACEHOLDER. Final wording is Bam's to design.
+ */
+export default function LockedInRefreshNotice({ lockedSats }: { lockedSats: number }) {
+    const arkWallet = useAuthStore((s) => s.arkWallet);
+
+    const goToCapsules = () => {
+        dispatchNavigate('CheckingAccountNew', {
+            wallet: arkWallet,
+            accountType: 'ark',
+            initialTab: 0, // Ark's tab 0 = Capsules (where refresh can be cancelled)
+        });
+    };
+
+    return (
+        <View
+            style={{
+                marginTop: 12,
+                marginHorizontal: 4,
+                padding: 12,
+                borderRadius: 10,
+                backgroundColor: 'rgba(255, 200, 80, 0.06)',
+                borderWidth: 1,
+                borderColor: 'rgba(255, 200, 80, 0.30)',
+            }}
+        >
+            <Text style={{ fontSize: 12, color: '#CCC', lineHeight: 17 }}>
+                {lockedSats.toLocaleString()} sats are in a pending refresh, not lost.
+                Cancel the refresh from Capsules to spend them.
+            </Text>
+            <TouchableOpacity
+                onPress={goToCapsules}
+                style={{
+                    marginTop: 10,
+                    paddingVertical: 10,
+                    borderRadius: 8,
+                    alignItems: 'center',
+                    backgroundColor: '#FFD54F',
+                }}
+            >
+                <Text bold style={{ fontSize: 13, color: '#1C1C1C' }}>
+                    Go to Capsules to cancel refresh
+                </Text>
+            </TouchableOpacity>
+        </View>
+    );
+}

--- a/src/custom-hooks/useArkSync.ts
+++ b/src/custom-hooks/useArkSync.ts
@@ -38,6 +38,7 @@ import { processArkMovementsForActivity } from '@Cypher/services/ark/movementsAc
 // Imported from the file path directly (not the @Cypher/services/ark
 // barrel) — the barrel doesn't re-export the expiry module.
 import { formatBlocksUntil } from '@Cypher/services/ark/expiry';
+import { buildDeferredVtxoIds } from '@Cypher/services/ark/refreshDeferral';
 import useAuthStore from '@Cypher/stores/authStore';
 import { recordEvent } from '@Cypher/stores/eventLogStore';
 import {
@@ -126,14 +127,14 @@ const REFRESH_FAIL_ALERT_GAP_MS = 6 * 60 * 60 * 1000;
 
 // --- Stuck-refresh swap-out window + auto-cancel safety net ----------------
 //
-// When a round is detected stuck (useArkSync flags it past 2× the round
+// When a round is detected stuck (useArkSync flags it past 2x the round
 // interval) AND its Locked VTXOs are inside this window of their pre-refresh
 // expiry, the UX escalates from "cancel & retry the refresh" to "move your
-// funds out": swap-out notifications (12h/6h/3h) are scheduled and the
-// in-app banners route to ArkStuckCapsuleScreen. 12h matches the product
-// decision to keep the 24h warning as a normal refresh prompt (a fresh
-// arkoor receive legitimately sits near 24h) and only escalate from 12h.
-const STUCK_SWAP_WINDOW_MS = 12 * 60 * 60 * 1000;
+// funds out": swap-out notifications are scheduled and the in-app banners
+// route to ArkStuckCapsuleScreen. 24h gives a full day of runway for the
+// cooperative swap-out or exit before the funds expire, so a stuck round this
+// close to expiry surfaces the escape hatch rather than just a cancel prompt.
+const STUCK_SWAP_WINDOW_MS = 24 * 60 * 60 * 1000;
 // Auto-cancel safety net: once a stuck round's Locked funds are inside this
 // window of expiry, cancel the wedged round automatically so the VTXOs unlock
 // with enough runway for the user to still swap / exit before the deadline.
@@ -939,12 +940,7 @@ export default function useArkSync(): UseArkSync {
             // movementWatcher pushing the entry and the user tapping a
             // button, so the race-winner is the user, not the scheduler.
             const promptState = state.arkArkoorPromptState ?? {};
-            const deferredIds = new Set<string>();
-            for (const [id, entry] of Object.entries(promptState)) {
-                if (entry.status === 'pending' || entry.status === 'dismissed') {
-                    deferredIds.add(id);
-                }
-            }
+            const deferredIds = buildDeferredVtxoIds(promptState);
             let minBlocks = Infinity;
             // Same minimum but INCLUDING user-deferred VTXOs — the
             // failure-streak escalation below uses this one. Deferring

--- a/src/custom-hooks/useArkoorReceivePrompt.ts
+++ b/src/custom-hooks/useArkoorReceivePrompt.ts
@@ -10,6 +10,7 @@ import {
     refreshArkVtxosAndSync,
     scheduleVtxoExpiryWarnings,
 } from '@Cypher/services/ark';
+import { SPEND_GRACE_MS } from '@Cypher/services/ark/refreshDeferral';
 import useAuthStore from '@Cypher/stores/authStore';
 import { recordEvent } from '@Cypher/stores/eventLogStore';
 
@@ -283,16 +284,26 @@ export default function useArkoorReceivePrompt(): void {
                             });
                             const cur = useAuthStore.getState().arkArkoorPromptState;
                             const existing = cur[firstId];
-                            if (existing) {
-                                setArkArkoorPromptState({
-                                    ...cur,
-                                    [firstId]: {
-                                        ...existing,
-                                        status: 'dismissed',
-                                        dismissedAt: Date.now(),
-                                    },
-                                });
-                            }
+                            const nowTs = Date.now();
+                            // Create-or-update so the "spend immediately" grace always
+                            // holds, even if the pending entry is somehow missing.
+                            // deferUntil holds auto-refresh off this vtxo for
+                            // SPEND_GRACE_MS, then it refreshes normally.
+                            setArkArkoorPromptState({
+                                ...cur,
+                                [firstId]: {
+                                    ...(existing ?? { observedAt: nowTs, sats: sats ?? undefined }),
+                                    status: 'dismissed',
+                                    dismissedAt: nowTs,
+                                    deferUntil: nowTs + SPEND_GRACE_MS,
+                                },
+                            });
+                            console.log(
+                                '[useArkoorReceivePrompt] use-immediately grace stamped',
+                                firstId.slice(0, 12),
+                                'deferUntil=now+', Math.round(SPEND_GRACE_MS / 3600000), 'h',
+                                'existingFound=', !!existing,
+                            );
                             // Re-arm OS push warnings — idempotent per id, so this
                             // is a no-op if they were already scheduled at
                             // observation time. Belt + suspenders in case the

--- a/src/screens/Account/ArkSeedPhraseScreen/index.tsx
+++ b/src/screens/Account/ArkSeedPhraseScreen/index.tsx
@@ -231,7 +231,15 @@ export default function ArkSeedPhraseScreen() {
         } catch (err) {
             console.warn("[Ark] Wallet.create failed during backup setup:", err);
             const msg = (err as Error)?.message ?? "unknown error";
-            const looksLikeStaleDatadir = /Internal|InvalidMnemonic|Database/i.test(msg);
+            // bark's error strings for "a datadir already exists on disk but
+            // this seed can't open it": Internal / Database (0-byte or schema
+            // residue) and "incorrect mnemonic" (the datadir was created with a
+            // DIFFERENT seed, i.e. the poisoned-datadir trap left by a create that
+            // died mid-flight, e.g. the esplora bot-block). All three route to
+            // the user-confirmed Reset & retry below; without "incorrect
+            // mnemonic" here that case dead-ended on a bare toast and the only
+            // way out was reinstalling the app.
+            const looksLikeStaleDatadir = /Internal|InvalidMnemonic|Database|incorrect mnemonic/i.test(msg);
 
             // Non-stale-datadir errors: just toast and bail. Caller retries on next tap.
             if (!looksLikeStaleDatadir) {

--- a/src/screens/Account/RecoverArkScreen/index.tsx
+++ b/src/screens/Account/RecoverArkScreen/index.tsx
@@ -19,6 +19,7 @@ import {
     lookupArkBackupInLocalDocuments,
     lookupArkBackupInSafFolder,
     lookupArkBackupOnDrive,
+    ArkRestoreApplyError,
     restoreArkBackupBlob,
     setArkBackgroundRefreshEnabled,
 } from "@Cypher/services/ark";
@@ -340,6 +341,22 @@ export default function RecoverArkScreen() {
             // file path. See .claude/OPEN_BUGS.md for the original
             // diagnosis trail.
             if (result.kind === 'matched') {
+                // restoreArkBackupBlob decrypts + validates the manifest BEFORE
+                // it touches disk or the network. An ArkRestoreApplyError means
+                // those passed and only the apply/open step failed (server
+                // unreachable, or storage) — the file is provably intact, so it
+                // is NEVER corrupt. Reuse the same "backup is safe, retry"
+                // reassurance the network branch shows.
+                if (err instanceof ArkRestoreApplyError || err?.backupIntact === true) {
+                    console.warn('[Ark restore] apply/open failed after decrypt (file intact):', err);
+                    setRestoring(false);
+                    setErrorMsg(
+                        "Your backup file is intact, but the wallet couldn't reach the Ark server right now. " +
+                        "This is usually temporary. Check your internet connection and try again in a moment. " +
+                        "Your funds and seed are safe; no need to pick a different backup file.",
+                    );
+                    return true;
+                }
                 const msg = String(err?.message ?? '');
                 const isNetworkError =
                     msg.includes('BarkError.ServerConnection') ||

--- a/src/screens/Ark/ArkSendScreen/index.tsx
+++ b/src/screens/Ark/ArkSendScreen/index.tsx
@@ -22,6 +22,7 @@ import {
 } from '@Cypher/services/ark';
 import { colors } from '@Cypher/style-guide';
 import useAuthStore from '@Cypher/stores/authStore';
+import LockedInRefreshNotice from '@Cypher/components/LockedInRefreshNotice';
 
 /**
  * Decode the sat amount encoded in an amount-bearing BOLT11, or null if the
@@ -100,6 +101,10 @@ export default function ArkSendScreen({ route }: Props) {
     // useless in the UI. The store is kept fresh by the 30 s useArkSync tick.
     const arkBalance = useAuthStore((s) => s.arkBalance);
     const spendableSats = Number(arkBalance ?? 0);
+    // Sats locked in an in-flight refresh round. Spendable again once the
+    // round finalises or the user cancels it from the Capsules tab.
+    const arkBalanceDetail = useAuthStore((s) => s.arkBalanceDetail);
+    const pendingInRoundSats = Number(arkBalanceDetail?.pendingInRoundSats ?? 0);
 
     const [destinationRaw, setDestinationRaw] = useState<string>(
         route?.params?.initialDestination ?? '',
@@ -311,12 +316,15 @@ export default function ArkSendScreen({ route }: Props) {
                     Locked (mid-round) and needs a recovery / wait, not that
                     the amount is wrong. */}
                 {amountValid && !amountWithinBalance && (
-                    <Text style={styles.error}>
-                        Insufficient spendable balance: {spendableSats.toLocaleString()} sats available.
-                        {spendableSats === 0
-                            ? ' Your VTXO capsules may be locked in a pending round — try again once the round finalises, or recover from the Capsules tab.'
-                            : ''}
-                    </Text>
+                    pendingInRoundSats > 0 ? (
+                        // Funds aren't missing, they're locked in a refresh.
+                        // Point the user to Capsules to cancel it (see notice).
+                        <LockedInRefreshNotice lockedSats={pendingInRoundSats} />
+                    ) : (
+                        <Text style={styles.error}>
+                            Insufficient spendable balance: {spendableSats.toLocaleString()} sats available.
+                        </Text>
+                    )
                 )}
             </ScrollView>
 

--- a/src/screens/Ark/ArkStuckCapsuleScreen/index.tsx
+++ b/src/screens/Ark/ArkStuckCapsuleScreen/index.tsx
@@ -382,13 +382,13 @@ export default function ArkStuckCapsuleScreen() {
                             disabled={!canExit}
                             activeOpacity={0.7}
                             accessibilityRole="button"
-                            accessibilityLabel="Exit"
+                            accessibilityLabel="Rescue near-expired funds"
                             style={{ marginTop: 16, paddingVertical: 14, borderRadius: 12, alignItems: "center", backgroundColor: canExit ? accent : "#444" }}
                         >
                             {exiting ? (
                                 <ActivityIndicator color="#0B0B0B" />
                             ) : (
-                                <Text bold style={{ fontSize: 15, color: "#0B0B0B" }}>Exit</Text>
+                                <Text bold style={{ fontSize: 15, color: "#0B0B0B" }}>Rescue near-expired funds</Text>
                             )}
                         </TouchableOpacity>
                     </>

--- a/src/screens/HomeScreen/WalletsView/index.tsx
+++ b/src/screens/HomeScreen/WalletsView/index.tsx
@@ -434,7 +434,17 @@ const WalletsView = forwardRef<WalletsViewHandle, Props>(function WalletsView({
             // item length 0" (observed on the A14 right after this effect
             // ran). The remount is the whole fix; nothing to scroll.
         }
-    }, [allBTCWallets, isLoading, matchedRateStrike, strikeBalance, convertedRate]);
+    }, [
+        allBTCWallets, isLoading, matchedRateStrike, strikeBalance, convertedRate,
+        // isArkAuth gates the Ark card (see `hasArk` above). Recovery writes
+        // isArkAuth and allBTCWallets in SEPARATE store updates, and the
+        // HomeScreen remount reconciles isArkAuth against disk, so this effect
+        // can run with 'ARK' already in the list while isArkAuth is still
+        // false, build wTabs WITHOUT the Ark card, then never rebuild when
+        // isArkAuth flips true. Without it here the recovered card only appears
+        // after a manual swipe / navigate-away-and-back forces a fresh build.
+        isArkAuth,
+    ]);
 
     // Maps a tab's `key` to the wallet "kind" used to color the page-indicator
     // line in BalanceView. Centralized here so the carousel and the indicator

--- a/src/screens/Send/index.tsx
+++ b/src/screens/Send/index.tsx
@@ -112,7 +112,17 @@ export default function SendScreen({ navigation, route }: any) {
     const [isScannerActive, setIsScannerActive] = useState(false);
     const [addressFocused, setAddressFocused] = useState(false);
     const [maxUSD, setMaxUSD] = useState(0);
-    const [isPaste, setIsPaste] = useState(info?.destination && info?.destination?.startsWith('ln') ? true : false)
+    // Treat a Lightning invoice that arrives pre-filled via EITHER `to`
+    // (scanner / deep-link) or `destination` (paste flow) as a paste, so the
+    // amount-decode effect below runs and fills in the invoice amount.
+    // Previously this only checked `destination`, so a scanned invoice that
+    // landed in `to` left isPaste false and the amount stuck at 0. Lowercased
+    // because QR-encoded BOLT11 is often uppercase. Withdrawals set their own
+    // amount, so they opt out.
+    const [isPaste, setIsPaste] = useState(
+        !info?.isWithdrawal &&
+        (info?.to || info?.destination || '').trim().toLowerCase().startsWith('ln'),
+    )
     const [maxBalance, setMaxBalance] = useState<number>(0);
 
     useEffect(() => {
@@ -145,14 +155,15 @@ export default function SendScreen({ navigation, route }: any) {
     }, [info])
 
     useEffect(() => {
-        if (!sender.startsWith('ln') && !sender.includes('@') && !recommendedFee) {
+        const lnSender = sender.trim().toLowerCase();
+        if (!lnSender.startsWith('ln') && !sender.includes('@') && !recommendedFee) {
             const init = async () => {
                 const res = await bitcoinRecommendedFee();
                 setRecommendedFee(res);
                 console.log('recommendedFee: ', res)
             }
             init();
-        } else if (sender.startsWith('ln') && isPaste){
+        } else if (lnSender.startsWith('ln') && isPaste){
             // Two paths for a pasted Lightning invoice:
             //   1. Screen was opened with a pre-filled `info.destination`
             //      (e.g. deep-link / share-extension flow): the existing
@@ -166,7 +177,7 @@ export default function SendScreen({ navigation, route }: any) {
             if (info?.destination) {
                 setTimeout(() => handleLighteningInvoice(), 500);
             } else {
-                const trimmed = sender.trim();
+                const trimmed = sender.trim().toLowerCase();
                 const decodedSats = decodeBolt11Sats(trimmed);
                 if (decodedSats !== null && decodedSats > 0) {
                     // Compute fiat now so we can both populate the field
@@ -570,6 +581,12 @@ export default function SendScreen({ navigation, route }: any) {
                                                 onChange={newValue => {
                                                     console.log('newValue: ', newValue)
                                                     setSender(newValue);
+                                                    // A scanned/pasted Lightning invoice can land in the
+                                                    // field directly (e.g. the keyboard's Scan Text)
+                                                    // without going through the paste/scan buttons, which
+                                                    // were the only places isPaste got set. Flag it so the
+                                                    // amount-decode effect below runs and fills the amount.
+                                                    if (newValue.trim().toLowerCase().startsWith('ln')) setIsPaste(true);
                                                 }}
                                                 value={!sender.includes('@') && sender.length > 20 ? shortenAddress(sender) : sender}
                                                 textInputStyle={styles.senderText}

--- a/src/screens/Strike/CheckingAccountNew/ArkCapsules.tsx
+++ b/src/screens/Strike/CheckingAccountNew/ArkCapsules.tsx
@@ -39,6 +39,7 @@ import {
     formatBlocksUntil,
 } from "@Cypher/services/ark/expiry";
 import { buildRefreshBatch } from "@Cypher/services/ark/refreshBatch";
+import { buildDeferredVtxoIds } from "@Cypher/services/ark/refreshDeferral";
 import useAuthStore from "@Cypher/stores/authStore";
 import { colors, widths } from "@Cypher/style-guide";
 import vaultStyles from "../../HotStorageVault/styles";
@@ -110,6 +111,18 @@ function getExpiryView(daysLeft: number): ExpiryView {
     if (daysLeft >= 14) return { status: "yellow", color: colors.ark.light, fractionLeft };
     if (daysLeft >= 7)  return { status: "orange", color: "#FB923C",        fractionLeft };
     return                      { status: "red",   color: colors.redLight,  fractionLeft };
+}
+
+/**
+ * Day + hour precision for the per-row "time left" label, e.g. "1d 16h left"
+ * or "16h left". A flat "1d" is misleading near expiry (1d and 1d-23h read the
+ * same); showing the hours makes the countdown honest.
+ */
+function formatExpiryLeft(daysLeft: number): string {
+    const totalHours = Math.max(0, Math.round(daysLeft * 24));
+    const d = Math.floor(totalHours / 24);
+    const h = totalHours % 24;
+    return d > 0 ? `${d}d ${h}h left` : `${h}h left`;
 }
 
 // --- Ring constants ---
@@ -246,6 +259,12 @@ interface VtxoRowProps {
     isCancelling: boolean;
     /** Round cadence in seconds (from wallet.arkInfo()), null until fetched. */
     roundIntervalSecs: number | null;
+    /**
+     * Consecutive refresh failures (arkRefreshFailStreak). When > 0 and the
+     * capsule is mid-refresh, the row shows "⚠️ N refresh attempt(s) failed"
+     * instead of the "takes less than 3 hours" reassurance.
+     */
+    failedAttempts?: number;
 }
 
 /**
@@ -266,7 +285,7 @@ function formatRoundUpperBound(secs: number): string {
  * "coin" column (depletion ring instead of UTXO capsule mask), and the
  * selection halo color is yellow (Ark) instead of green (Vault).
  */
-function VtxoRow({ vtxo, selected, onPress, onRefreshIcon, onCancelIcon, isCancelling, roundIntervalSecs }: VtxoRowProps) {
+function VtxoRow({ vtxo, selected, onPress, onRefreshIcon, onCancelIcon, isCancelling, roundIntervalSecs, failedAttempts }: VtxoRowProps) {
     const view = getExpiryView(vtxo.daysLeft);
     const BTCAmount = formatCapsuleAmount(vtxo.sats);
 
@@ -353,13 +372,15 @@ function VtxoRow({ vtxo, selected, onPress, onRefreshIcon, onCancelIcon, isCance
             : view.color;
     const labelText = isTransientForLabel
         ? (isCancelling
-            ? 'Cancelling\n(takes less than an hour)'
-            : 'Refreshing or In-flight\n(takes less than an hour)')
+            ? 'Cancelling\n(takes less than 3 hours)'
+            : (failedAttempts && failedAttempts > 0
+                ? `Refreshing or In-flight\n⚠️ ${failedAttempts} refresh attempt${failedAttempts === 1 ? '' : 's'} failed`
+                : 'Refreshing or In-flight\n(takes less than 3 hours)'))
         : isExpired
             ? 'Expired'
             : vtxo.unknownExpiry
                 ? vtxo.kind
-                : `${Math.max(0, Math.round(vtxo.daysLeft))}d left`;
+                : formatExpiryLeft(vtxo.daysLeft);
     const ringDaysLeft = isTransientForLabel ? VTXO_MAX_DAYS : vtxo.daysLeft;
 
     // Explainer for expired capsules — the only "action" the row keeps.
@@ -1006,6 +1027,12 @@ export default function ArkCapsules({ matchedRate, currency }: ArkCapsulesProps)
     // useArkSync's stuck detection. Drives the per-round 3h countdowns in the
     // refresh-wait banner. Auto-prunes when a round completes.
     const arkPendingRoundFirstSeen = useAuthStore((s) => s.arkPendingRoundFirstSeen);
+    // Subscribed (not getState) so the dust-consolidate banner re-derives when
+    // a "Use immediately" grace is set/lapses and stops auto-sweeping that vtxo.
+    const arkArkoorPromptState = useAuthStore((s) => s.arkArkoorPromptState);
+    // Consecutive refresh failures, drives the per-row "N refresh attempts
+    // failed" copy while a capsule is stuck mid-refresh.
+    const arkRefreshFailStreak = useAuthStore((s) => s.arkRefreshFailStreak);
 
     // Recover a stuck refresh from the Capsules tab. Mirrors the home-card
     // handler in ArkWallet — but that banner is invisible to a user sitting
@@ -1191,17 +1218,11 @@ export default function ArkCapsules({ matchedRate, currency }: ArkCapsulesProps)
         setArkPendingTapRefresh(false);
 
         // Honour user-deferred VTXOs ("Use immediately" from the arkoor
-        // receive popup). Mirrors the deferred-set logic in
-        // src/services/ark/backgroundRefresh.ts so the tap and bg paths
-        // agree on what's off-limits.
+        // receive popup), via the shared gate so the tap and bg paths agree
+        // on what's off-limits (3h grace, unanswered popups, 90s race window).
         const promptState =
             useAuthStore.getState().arkArkoorPromptState ?? {};
-        const deferredIds = new Set<string>();
-        for (const [id, entry] of Object.entries(promptState)) {
-            if (entry.status === 'pending' || entry.status === 'dismissed') {
-                deferredIds.add(id);
-            }
-        }
+        const deferredIds = buildDeferredVtxoIds(promptState);
 
         const batch = buildRefreshBatch({
             vtxos: rows.map((r) => ({
@@ -1661,12 +1682,7 @@ export default function ArkCapsules({ matchedRate, currency }: ArkCapsulesProps)
         const freshTip = useAuthStore.getState().arkChainTipHeight;
         const freshPromptState =
             useAuthStore.getState().arkArkoorPromptState ?? {};
-        const freshDeferredIds = new Set<string>();
-        for (const [id, entry] of Object.entries(freshPromptState)) {
-            if (entry.status === 'pending' || entry.status === 'dismissed') {
-                freshDeferredIds.add(id);
-            }
-        }
+        const freshDeferredIds = buildDeferredVtxoIds(freshPromptState);
         const projected = freshVtxos.map((v) => {
             const pending = v.state.toLowerCase() === 'locked';
             if (v.expiryHeight === 0 || freshTip === null) {
@@ -1913,9 +1929,12 @@ export default function ArkCapsules({ matchedRate, currency }: ArkCapsulesProps)
         // ASP rejects it for being past its lifetime — so trying to
         // include it would just nuke the whole consolidation attempt.
         // Also exclude pendingRound capsules (already in flight, double-
-        // submission would confuse the SDK).
+        // submission would confuse the SDK). And exclude vtxos inside their
+        // "Use immediately" grace; this button auto-selects the set, so it
+        // must honour the same consent every other automatic path does.
+        const deferredIds = buildDeferredVtxoIds(arkArkoorPromptState);
         const dust = rows.filter(
-            (r) => r.sats <= ARK_VTXO_DUST_SATS && !r.pendingRound && r.daysLeft > 0,
+            (r) => r.sats <= ARK_VTXO_DUST_SATS && !r.pendingRound && r.daysLeft > 0 && !deferredIds.has(r.id),
         );
         if (dust.length === 0) {
             return { dust, ids: [] as string[], total: 0, viable: false, shortfall: 0 };
@@ -1934,7 +1953,7 @@ export default function ArkCapsules({ matchedRate, currency }: ArkCapsulesProps)
         // input set would poison the whole consolidation round the same
         // way expired dust would.
         const nonDust = rows
-            .filter((r) => r.sats > ARK_VTXO_DUST_SATS && !r.pendingRound && r.daysLeft > 0)
+            .filter((r) => r.sats > ARK_VTXO_DUST_SATS && !r.pendingRound && r.daysLeft > 0 && !deferredIds.has(r.id))
             .sort((a, b) => a.sats - b.sats);
         const fillers: typeof rows = [];
         let total = dustTotal;
@@ -1951,7 +1970,7 @@ export default function ArkCapsules({ matchedRate, currency }: ArkCapsulesProps)
             viable,
             shortfall: viable ? 0 : ARK_REFRESH_MIN_SATS - total,
         };
-    }, [rows]);
+    }, [rows, arkArkoorPromptState]);
 
     const handleConsolidateDust = () => {
         if (!dustConsolidate.viable || dustConsolidate.ids.length < 2) return;
@@ -2221,6 +2240,7 @@ export default function ArkCapsules({ matchedRate, currency }: ArkCapsulesProps)
                         onCancelIcon={handleRowCancel}
                         isCancelling={cancelling}
                         roundIntervalSecs={arkRoundIntervalSecs}
+                        failedAttempts={arkRefreshFailStreak}
                     />
                 )}
                 // Pending LN receives render ABOVE the VTXO list. They're

--- a/src/screens/Strike/CheckingAccountNew/index.tsx
+++ b/src/screens/Strike/CheckingAccountNew/index.tsx
@@ -2,7 +2,7 @@ import { ScreenLayout } from "@Cypher/component-library";
 import { Tabs } from "@Cypher/components";
 import useAuthStore from "@Cypher/stores/authStore";
 import { useRoute } from "@react-navigation/native";
-import React, { useCallback, useState } from "react";
+import React, { useCallback, useEffect, useState } from "react";
 import { View } from "react-native";
 import { default as Account, default as Vault } from "./Account";
 import ArkCapsules from "./ArkCapsules";
@@ -31,6 +31,13 @@ export default function CheckingAccountNew({ navigation, route }: any) {
         initialTab?: number,
     };
     const [selectedTab, setSelectedTab] = useState(initialTab ?? 0);
+    // Re-sync the active tab when navigated here with an explicit initialTab
+    // while this screen is already mounted (e.g. the send flow's locked-funds
+    // "Go to Capsules" notice → initialTab 0). useState above only captures the
+    // first value, so a back-navigation wouldn't otherwise switch tabs.
+    useEffect(() => {
+        if (typeof initialTab === 'number') setSelectedTab(initialTab);
+    }, [initialTab]);
     const { vaultTab, matchedRateStrike, strikeUser } = useAuthStore();
     const isArk = accountType === 'ark';
     // Strike branch (not Ark, not CoinOS-receive): rate + currency must

--- a/src/screens/SwapAmount/index.tsx
+++ b/src/screens/SwapAmount/index.tsx
@@ -8,6 +8,7 @@ import { GradientShock, Electricity } from "@Cypher/assets/images";
 import { dispatchNavigate, dispatchReset } from "@Cypher/helpers";
 import { colors } from "@Cypher/style-guide";
 import useAuthStore from "@Cypher/stores/authStore";
+import LockedInRefreshNotice from "@Cypher/components/LockedInRefreshNotice";
 import SimpleToast from "react-native-simple-toast";
 import { StyleSheet } from "react-native";
 import {
@@ -34,6 +35,12 @@ export default function SwapAmount() {
         sourceBalance?: number;
     };
     const { matchedRateStrike, strikeUser } = useAuthStore();
+    // Ark sats locked in an in-flight refresh. When the source is Ark and the
+    // user can't cover the swap because funds are locked, point them to
+    // Capsules to cancel the refresh (see LockedInRefreshNotice) rather than
+    // letting the swap fail with an opaque insufficient-balance error.
+    const arkBalanceDetail = useAuthStore((s) => s.arkBalanceDetail);
+    const pendingInRoundSats = Number(arkBalanceDetail?.pendingInRoundSats ?? 0);
     // Currency and rate are rail-specific. Strike carries the user's
     // configured fiat currency (e.g. EUR) and a Strike-side rate in that
     // currency. Every other rail uses USD and BlueWallet's USD/BTC rate
@@ -94,7 +101,15 @@ export default function SwapAmount() {
      * — providers that don't quote ahead of time return null and we
      * default to 0 (no reserve, same as before for Coinos/Strike).
      */
-    const [maxFeeReserve, setMaxFeeReserve] = useState<number>(0);
+    // Conservative headroom held back on the Max button UNTIL the provider's
+    // precise reserve finishes seeding (in the effect below). That seed is
+    // async: it hits the ASP, and on Ark a chain-tip fetch that can stall for
+    // seconds while esplora is rate-limited (429). Seeding this at 0 let Max
+    // momentarily equal the full spendable balance, which then fails the send
+    // preflight ("amount + routing fee > spendable"). Seeding it at a safe
+    // holdback that only ever DECREASES to the real reserve closes that race.
+    const MAX_RESERVE_SEEDING_HOLDBACK = 500;
+    const [maxFeeReserve, setMaxFeeReserve] = useState<number>(MAX_RESERVE_SEEDING_HOLDBACK);
 
     // One-shot Max-button reserve at mount. Two-stage lookup:
     //   1. Provider's `maxFeeReserve` — explicit headroom buffer (Coinos
@@ -120,8 +135,10 @@ export default function SwapAmount() {
                 }
                 if (!cancelled) setMaxFeeReserve(Math.max(0, reserve));
             } catch {
-                // Reserve is best-effort — fall back to 0 (full balance).
-                if (!cancelled) setMaxFeeReserve(0);
+                // Reserve is best-effort. Fall back to the safe holdback (NOT
+                // 0/full balance) so a failed seed can't let Max overshoot the
+                // "amount + fee ≤ spendable" preflight either.
+                if (!cancelled) setMaxFeeReserve(MAX_RESERVE_SEEDING_HOLDBACK);
             }
         })();
         return () => { cancelled = true; };
@@ -419,6 +436,9 @@ export default function SwapAmount() {
         <ScreenLayout disableScroll showToolbar isBackButton title="Lightning Swap">
             <View style={styles.main}>
                 <GradientInput isSats={isSats} walletInfo={{ matchedRate, currency }} sats={sats} setSats={setSats} usd={usd} />
+                {swapFrom === 'ark' && pendingInRoundSats > 0 && (sourceBalance === 0 || (Number(sats) || 0) > sourceBalance) && (
+                    <LockedInRefreshNotice lockedSats={pendingInRoundSats} />
+                )}
                 <View style={styles.directionRow}>
                     {renderProviderBadge(fromProvider, swapFrom, 'inline')}
                     <Text style={styles.arrow}>→</Text>

--- a/src/services/ark/backgroundRefresh.ts
+++ b/src/services/ark/backgroundRefresh.ts
@@ -12,6 +12,7 @@ import {
     fetchArkPendingRoundStates,
     refreshArkVtxosAndSync,
 } from './refresh';
+import { buildDeferredVtxoIds } from './refreshDeferral';
 import { fetchArkVtxos } from './vtxos';
 import { getArkWalletHandle, getCachedArkMnemonic } from './walletHandle';
 import {
@@ -495,22 +496,12 @@ export async function runBackgroundRefresh(
         //        new vtxo gets pulled into the round as a filler.
         // Adding the time-window check picks up arkoors that arrived
         // mid-orchestrator and prevents them from being swept.
-        const RECENT_WINDOW_MS = 90_000; // 90s — covers a slow ASP round + sync lag
         const promptState = useAuthStore.getState().arkArkoorPromptState ?? {};
-        const nowForGate = Date.now();
-        const deferredIds = new Set<string>();
-        for (const [id, entry] of Object.entries(promptState)) {
-            if (entry.status === 'pending' || entry.status === 'dismissed') {
-                deferredIds.add(id);
-                continue;
-            }
-            // Recently observed but somehow not pending (e.g. user already
-            // resolved it via popup but the entry hasn't been pruned yet).
-            // Don't double-refresh.
-            if (entry.observedAt && nowForGate - entry.observedAt < RECENT_WINDOW_MS) {
-                deferredIds.add(id);
-            }
-        }
+        // Skip vtxos inside the "Use immediately" 3h grace, unanswered arkoor
+        // popups, and 90s-fresh arrivals (mid-orchestrator race). Shared with
+        // every other automatic refresh path via buildDeferredVtxoIds. A
+        // 'dismissed' vtxo whose grace has lapsed is intentionally NOT skipped.
+        const deferredIds = buildDeferredVtxoIds(promptState);
         console.log(
             '[Ark bg refresh] deferral set:',
             deferredIds.size,
@@ -678,17 +669,10 @@ export async function runBackgroundRefresh(
         {
             const latestPromptState =
                 useAuthStore.getState().arkArkoorPromptState ?? {};
+            const latestDeferred = buildDeferredVtxoIds(latestPromptState);
             const lateAddedDeferred = new Set<string>();
-            const lateNow = Date.now();
-            for (const [id, entry] of Object.entries(latestPromptState)) {
-                if (deferredIds.has(id)) continue; // already accounted for at categorization
-                if (
-                    entry.status === 'pending' ||
-                    entry.status === 'dismissed' ||
-                    (entry.observedAt && lateNow - entry.observedAt < RECENT_WINDOW_MS)
-                ) {
-                    lateAddedDeferred.add(id);
-                }
+            for (const id of latestDeferred) {
+                if (!deferredIds.has(id)) lateAddedDeferred.add(id); // newly deferred since categorization
             }
             if (lateAddedDeferred.size > 0) {
                 const droppedFromBatch = batchIds.filter((id) =>

--- a/src/services/ark/backup.ts
+++ b/src/services/ark/backup.ts
@@ -159,7 +159,8 @@ import {
     writeArkBackupToSaf,
 } from './safFolderBackup';
 import type { SafBackupOutcome } from './safFolderBackup';
-import { clearArkWalletHandle, openArkWallet } from './walletHandle';
+import { clearArkWalletHandle } from './walletHandle';
+import { openArkWalletWithRotation } from './restore';
 
 /**
  * Ark datadir backup / restore — Phase 2A: manual encrypted file export.
@@ -960,6 +961,30 @@ async function decryptBackupBlob(blob: string, mnemonic: string): Promise<Backup
 }
 
 /**
+ * Thrown by `restoreArkBackupBlob` when decrypt + manifest validation SUCCEEDED
+ * but applying the backup failed — the datadir write (e.g. ENOSPC) or the final
+ * `Wallet.open` (esplora/ASP unreachable). At this point the backup FILE is
+ * provably intact, so the recovery UI must NOT show "Backup file is corrupt";
+ * it should reassure the user their funds are safe and prompt a retry. See the
+ * esplora note in config.ts for the original mislabel this prevents.
+ *
+ * `backupIntact` is duck-typed so callers can detect it even if `instanceof`
+ * is defeated by class-transpilation of the Error subclass.
+ */
+export class ArkRestoreApplyError extends Error {
+    readonly backupIntact = true as const;
+    readonly innerError?: unknown;
+    constructor(innerError: unknown) {
+        const inner = (innerError as Error)?.message;
+        super(inner ? `Backup restore could not complete: ${inner}` : 'Backup restore could not complete');
+        this.name = 'ArkRestoreApplyError';
+        this.innerError = innerError;
+        // Guard instanceof against Babel's Error-subclass transpile gotcha.
+        Object.setPrototypeOf(this, ArkRestoreApplyError.prototype);
+    }
+}
+
+/**
  * Restore a backup blob into a fresh datadir and open the wallet.
  *
  * Steps, in order:
@@ -1000,48 +1025,63 @@ export async function restoreArkBackupBlob(
         }
     }
 
-    // Step 2: close the wallet so SQLite handles release file descriptors.
-    // Awaiting is required — the movement watcher's holder destroy
-    // happens asynchronously and pins SQLite FDs until it runs.
-    // Without the await, the subsequent unlink races the watcher's
-    // teardown and the restore fails with BarkError.Database (we hit
-    // this exact mode during the seed-only recovery testing — see
-    // walletHandle.clearArkWalletHandle).
-    await clearArkWalletHandle();
+    // Everything past decrypt + manifest validation is "the backup was good,
+    // now apply it." If teardown, the datadir write (e.g. ENOSPC), or the
+    // wallet open (esplora/ASP unreachable) throws, the FILE is provably intact
+    // — decrypt already succeeded above — so surface it as a typed
+    // ArkRestoreApplyError. The recovery UI keys off that to reassure the user
+    // and prompt a retry instead of the false "Backup file is corrupt" scare
+    // (see config.ts esplora note for the 45-minute misdiagnosis this caused).
+    try {
+        // Step 2: close the wallet so SQLite handles release file descriptors.
+        // Awaiting is required — the movement watcher's holder destroy
+        // happens asynchronously and pins SQLite FDs until it runs.
+        // Without the await, the subsequent unlink races the watcher's
+        // teardown and the restore fails with BarkError.Database (we hit
+        // this exact mode during the seed-only recovery testing — see
+        // walletHandle.clearArkWalletHandle).
+        await clearArkWalletHandle();
 
-    // Step 3+4: nuke and recreate datadir. Don't use deleteArkDatadir() since
-    // it flips the `ensured` latch in datadir.ts and we want to resume using
-    // the same path; a follow-up ensureArkDatadir handles re-creation.
-    if (await RNFS.exists(ARK_DATADIR)) {
-        await RNFS.unlink(ARK_DATADIR);
-    }
-    const datadir = await ensureArkDatadir();
-
-    // Step 5: write files. mkdirp parents per entry — manifest doesn't
-    // explicitly list directories.
-    for (const f of manifest.files) {
-        // Existing backups in the wild captured the datadir LOCK file.
-        // Restoring it plants another process's lock into the fresh
-        // datadir, which bark 0.3.0's lock manager can refuse to open.
-        // Locks are runtime state; the wallet recreates what it needs.
-        if (isLockArtifact(f.path)) continue;
-        const full = `${datadir}/${f.path}`;
-        const lastSlash = full.lastIndexOf('/');
-        if (lastSlash > 0) {
-            const parent = full.slice(0, lastSlash);
-            if (!(await RNFS.exists(parent))) {
-                await RNFS.mkdir(parent, {
-                    NSURLIsExcludedFromBackupKey: true,
-                    NSFileProtectionKey:
-                        'NSFileProtectionCompleteUntilFirstUserAuthentication',
-                });
-            }
+        // Step 3+4: nuke and recreate datadir. Don't use deleteArkDatadir()
+        // since it flips the `ensured` latch in datadir.ts and we want to
+        // resume using the same path; a follow-up ensureArkDatadir re-creates.
+        if (await RNFS.exists(ARK_DATADIR)) {
+            await RNFS.unlink(ARK_DATADIR);
         }
-        await RNFS.writeFile(full, f.b64, 'base64');
-    }
+        const datadir = await ensureArkDatadir();
 
-    // Step 6: open the wallet — should succeed now that datadir + seed agree.
-    await openArkWallet(mnemonic);
+        // Step 5: write files. mkdirp parents per entry — manifest doesn't
+        // explicitly list directories.
+        for (const f of manifest.files) {
+            // Existing backups in the wild captured the datadir LOCK file.
+            // Restoring it plants another process's lock into the fresh
+            // datadir, which bark 0.3.0's lock manager can refuse to open.
+            // Locks are runtime state; the wallet recreates what it needs.
+            if (isLockArtifact(f.path)) continue;
+            const full = `${datadir}/${f.path}`;
+            const lastSlash = full.lastIndexOf('/');
+            if (lastSlash > 0) {
+                const parent = full.slice(0, lastSlash);
+                if (!(await RNFS.exists(parent))) {
+                    await RNFS.mkdir(parent, {
+                        NSURLIsExcludedFromBackupKey: true,
+                        NSFileProtectionKey:
+                            'NSFileProtectionCompleteUntilFirstUserAuthentication',
+                    });
+                }
+            }
+            await RNFS.writeFile(full, f.b64, 'base64');
+        }
+
+        // Step 6: open the wallet — rotate esplora providers (matching the boot
+        // path) so a single provider bot-blocking bark's client doesn't fail
+        // the whole recovery. A single non-rotating open here was the recovery
+        // failure surfaced on device (2026-07-17): esplora threw at open and
+        // the screen mislabeled the intact backup "corrupt."
+        await openArkWalletWithRotation(mnemonic);
+    } catch (err) {
+        throw new ArkRestoreApplyError(err);
+    }
 }
 
 /**

--- a/src/services/ark/index.ts
+++ b/src/services/ark/index.ts
@@ -74,6 +74,7 @@ export {
     isICloudBackupAvailable,
     migrateLegacyBackupFile,
     peekBackupHeader,
+    ArkRestoreApplyError,
     restoreArkBackupBlob,
     writeArkAutoBackup,
     writeAndVerifyArkBackup,

--- a/src/services/ark/refreshDeferral.ts
+++ b/src/services/ark/refreshDeferral.ts
@@ -1,0 +1,62 @@
+/**
+ * Shared "don't auto-refresh this vtxo yet" gate.
+ *
+ * Every AUTOMATIC refresh path (background orchestrator, foreground urgency
+ * sweep, notification-tap batch, stuck-round retry, dust consolidate) consults
+ * this so the user's "Use immediately" choice is honored consistently in one
+ * place. Manual, user-tapped refresh deliberately does NOT consult it. An
+ * explicit tap on a specific capsule is the user changing their mind.
+ */
+
+/**
+ * How long "Use immediately" holds auto-refresh off a vtxo. Well under any vtxo
+ * expiry (days), so the grace lapses and the vtxo still auto-refreshes in time.
+ */
+export const SPEND_GRACE_MS = 3 * 60 * 60 * 1000; // 3 hours
+
+/**
+ * Freshly-observed arkoors are deferred regardless of prompt state, to close
+ * the race where a receive lands mid-orchestrator (the state snapshot was taken
+ * before the receive movement was recorded).
+ */
+export const RECENT_OBSERVE_WINDOW_MS = 90_000; // 90s
+
+type PromptEntry = {
+    status?: 'pending' | 'dismissed' | 'refreshed';
+    observedAt?: number;
+    deferUntil?: number;
+};
+
+/**
+ * Build the set of vtxo ids that automatic refresh must skip:
+ *   - status 'pending'      → arkoor popup not answered yet, don't touch it
+ *   - deferUntil in future  → inside the "spend immediately" grace window
+ *   - observedAt within 90s → race protection for mid-orchestrator arrivals
+ *
+ * Note: a plain 'dismissed' whose deferUntil has elapsed (or was never set) is
+ * NOT deferred. That is the point of the grace being time-boxed. Previously
+ * 'dismissed' deferred permanently, which could let a "use immediately" vtxo
+ * drift all the way to expiry unrefreshed.
+ */
+export function buildDeferredVtxoIds(
+    promptState: Record<string, PromptEntry> | undefined | null,
+    now: number = Date.now(),
+): Set<string> {
+    const ids = new Set<string>();
+    if (!promptState) return ids;
+    for (const [id, entry] of Object.entries(promptState)) {
+        if (!entry) continue;
+        if (entry.status === 'pending') {
+            ids.add(id);
+            continue;
+        }
+        if (typeof entry.deferUntil === 'number' && entry.deferUntil > now) {
+            ids.add(id);
+            continue;
+        }
+        if (typeof entry.observedAt === 'number' && now - entry.observedAt < RECENT_OBSERVE_WINDOW_MS) {
+            ids.add(id);
+        }
+    }
+    return ids;
+}

--- a/src/services/ark/restore.ts
+++ b/src/services/ark/restore.ts
@@ -147,6 +147,29 @@ async function openWithRetry(seed: string): Promise<ArkRestoreResult> {
 }
 
 /**
+ * Open the Ark wallet with the SAME esplora provider rotation the boot path
+ * uses, but THROW the last error on final failure instead of returning a
+ * result code. The `.cbark` restore flow (`restoreArkBackupBlob` in backup.ts)
+ * needs the failure to propagate so the recovery screen can tell a "decrypted
+ * fine, server unreachable" open failure apart from a genuinely corrupt backup.
+ *
+ * Reuses `openWithRetry` (transient-only retry + provider rotation) and the
+ * shared `openInFlight` guard so it can't race a boot/self-heal open against
+ * the same datadir.
+ */
+export async function openArkWalletWithRotation(seed: string): Promise<void> {
+    openInFlight = true;
+    try {
+        const result = await openWithRetry(seed);
+        if (!result.restored) {
+            throw result.error ?? new Error('Ark wallet open failed after trying all esplora providers');
+        }
+    } finally {
+        openInFlight = false;
+    }
+}
+
+/**
  * Self-heal re-open for the sync loop.
  *
  * `useArkRestoreOnBoot` runs exactly once per mount; if its open fails the

--- a/src/services/ark/walletHandle.ts
+++ b/src/services/ark/walletHandle.ts
@@ -156,7 +156,6 @@ export async function createArkWallet(
 ): Promise<WalletInterface> {
     await ensureUniffi();
     const datadir = await ensureArkDatadir();
-    const config = createArkConfig();
 
     // bark 0.11.3 consolidated open-or-create into a single `Wallet.open` with
     // `createIfNotExists`, so the old open-then-catch-then-`Wallet.create`
@@ -179,54 +178,79 @@ export async function createArkWallet(
         );
     }
 
-    try {
-        handle = await Wallet.open(
-            ARK_NETWORK,
-            mnemonic,
-            config,
-            WalletOpenArgs.create({ datadir, createIfNotExists: true }),
-        );
-    } catch (err) {
-        // Guarded cleanup for the poisoned-datadir trap (the cleanup the
-        // pre-0.11.3 open-catch-create fallback used to provide). A create
-        // that dies mid-flight (esplora unreachable, app killed) leaves a
-        // partial datadir bound to a mnemonic that no longer exists; every
-        // later create then fails on the mismatch and the user is stuck.
-        //
-        // Wipe-and-retry ONLY when both hold:
-        //   1. The failure is NOT network-shaped. Esplora/ASP outages throw
-        //      here too and the datadir is not the problem; wiping on those
-        //      would nuke state for nothing.
-        //   2. NO ark seed exists in the Keychain. bark cannot open a datadir
-        //      without its mnemonic, and the device's only copy lives at
-        //      KEYCHAIN_SERVICE; no seed = nothing can ever open this datadir
-        //      = failed-create residue. If a seed IS present the datadir may
-        //      be a live funded wallet, so never touch it.
-        //      getAllGenericPasswordServices is metadata-only (no FaceID);
-        //      if the query itself fails, fail SAFE and assume a seed exists.
-        const detail = `${(err as { tag?: string })?.tag ?? ''} ${(err as Error)?.message ?? String(err)}`;
-        const networkShaped =
-            /ServerConnection|Connection|connect|timeout|timed out|network|bad response from server/i.test(detail);
-        if (networkShaped) throw err;
+    // runDaemon: false on the create/recover path too (matches openArkWallet).
+    // The 0.11.3 SDK daemon defaults ON and runs its own maintenance-refresh
+    // below JS, which bypasses the "Use immediately" deferral and locks vtxos
+    // the user chose to keep spendable. Keep JS the sole refresh driver.
+    // Esplora rotation on create (mirrors the restore.ts open loop and
+    // ensureArkOnchainHandle below). A public esplora that bot-blocks bark's
+    // client, blockstream serves a ~338-byte Cloudflare page in place of chain
+    // data, surfacing as "bad response from server (not a blockhash)", would
+    // otherwise kill wallet creation outright, since the single-endpoint create
+    // had no fallback, unlike recovery which already rotates. attempt 0 is the
+    // same primary the old single-endpoint create used, so the happy path is
+    // unchanged; only a network-shaped failure rotates to the next provider.
+    for (let attempt = 0; attempt < ESPLORA_URLS.length; attempt++) {
+        const config = createArkConfig({ esploraAddress: ESPLORA_URLS[attempt] });
+        try {
+            handle = await Wallet.open(
+                ARK_NETWORK,
+                mnemonic,
+                config,
+                WalletOpenArgs.create({ datadir, createIfNotExists: true, runDaemon: false }),
+            );
+            break;
+        } catch (err) {
+            // Guarded cleanup for the poisoned-datadir trap (the cleanup the
+            // pre-0.11.3 open-catch-create fallback used to provide). A create
+            // that dies mid-flight (esplora unreachable, app killed) leaves a
+            // partial datadir bound to a mnemonic that no longer exists; every
+            // later create then fails on the mismatch and the user is stuck.
+            //
+            // Wipe-and-retry ONLY when both hold:
+            //   1. The failure is NOT network-shaped. Esplora/ASP outages throw
+            //      here too and the datadir is not the problem; wiping on those
+            //      would nuke state for nothing.
+            //   2. NO ark seed exists in the Keychain. bark cannot open a datadir
+            //      without its mnemonic, and the device's only copy lives at
+            //      KEYCHAIN_SERVICE; no seed = nothing can ever open this datadir
+            //      = failed-create residue. If a seed IS present the datadir may
+            //      be a live funded wallet, so never touch it.
+            //      getAllGenericPasswordServices is metadata-only (no FaceID);
+            //      if the query itself fails, fail SAFE and assume a seed exists.
+            const detail = `${(err as { tag?: string })?.tag ?? ''} ${(err as Error)?.message ?? String(err)}`;
+            const networkShaped =
+                /ServerConnection|Connection|connect|timeout|timed out|network|bad response from server/i.test(detail);
+            if (networkShaped) {
+                // The datadir is not the problem, so rotate to the next esplora
+                // and retry. Throw only after every provider has been tried.
+                if (attempt < ESPLORA_URLS.length - 1) {
+                    if (__DEV__) console.warn(`[Ark] create via ${ESPLORA_URLS[attempt]} failed (network-shaped: ${detail.trim()}); rotating esplora`);
+                    continue;
+                }
+                throw err;
+            }
 
-        const services = await Keychain.getAllGenericPasswordServices().catch(() => null);
-        const seedMayExist = services === null || services.includes(KEYCHAIN_SERVICE);
-        if (seedMayExist) {
-            console.warn('[Ark] Wallet.create failed with a keychain seed present; NOT wiping datadir:', detail);
-            throw err;
+            const services = await Keychain.getAllGenericPasswordServices().catch(() => null);
+            const seedMayExist = services === null || services.includes(KEYCHAIN_SERVICE);
+            if (seedMayExist) {
+                console.warn('[Ark] Wallet.create failed with a keychain seed present; NOT wiping datadir:', detail);
+                throw err;
+            }
+
+            console.warn('[Ark] Wallet.create failed on an orphaned datadir (no keychain seed); wiping residue and retrying once:', detail);
+            await clearArkWalletHandle();
+            await deleteArkDatadir();
+            const freshDatadir = await ensureArkDatadir();
+            handle = await Wallet.open(
+                ARK_NETWORK,
+                mnemonic,
+                config,
+                WalletOpenArgs.create({ datadir: freshDatadir, createIfNotExists: true, runDaemon: false }),
+            );
+            console.log('[Ark] Wallet.create retry after residue wipe succeeded');
+            break;
         }
-
-        console.warn('[Ark] Wallet.create failed on an orphaned datadir (no keychain seed); wiping residue and retrying once:', detail);
-        await clearArkWalletHandle();
-        await deleteArkDatadir();
-        const freshDatadir = await ensureArkDatadir();
-        handle = await Wallet.open(
-            ARK_NETWORK,
-            mnemonic,
-            config,
-            WalletOpenArgs.create({ datadir: freshDatadir, createIfNotExists: true }),
-        );
-        console.log('[Ark] Wallet.create retry after residue wipe succeeded');
     }
     cachedMnemonic = mnemonic;
     if (__DEV__) console.log('[Ark] Opened-or-created wallet in datadir');

--- a/src/stores/authStore.ts
+++ b/src/stores/authStore.ts
@@ -361,6 +361,15 @@ export type AuthStateType = {
         observedAt: number;
         dismissedAt?: number;
         /**
+         * "Spend immediately" grace: epoch-ms until which auto-refresh must
+         * leave this vtxo alone. Set to now + SPEND_GRACE_MS when the user taps
+         * "Use immediately" so the choice actually holds, then lapses so the
+         * vtxo can auto-refresh again well before expiry. Absent on entries
+         * from before this field / on non-"use-immediately" dismissals; those
+         * are NOT grace-deferred. Manual (user-tapped) refresh ignores this.
+         */
+        deferUntil?: number;
+        /**
          * Sats from the Bark movement event's `effectiveBalanceSats`.
          * Stored at push time so the popup can render the amount even
          * when the vtxo has already been Locked into a refresh round
@@ -418,6 +427,8 @@ export type AuthStateType = {
             status: 'pending' | 'dismissed' | 'refreshed';
             observedAt: number;
             dismissedAt?: number;
+            deferUntil?: number;
+            sats?: number;
         }>,
     ) => void;
     setArkArkoorPromptEnabled: (state: boolean) => void;

--- a/tests/unit/refreshDeferral.test.ts
+++ b/tests/unit/refreshDeferral.test.ts
@@ -1,0 +1,75 @@
+import {
+    buildDeferredVtxoIds,
+    SPEND_GRACE_MS,
+    RECENT_OBSERVE_WINDOW_MS,
+} from '../../src/services/ark/refreshDeferral';
+
+describe('buildDeferredVtxoIds spend-immediately consent gate', () => {
+    const now = 1_700_000_000_000;
+
+    it('defers a vtxo whose arkoor popup is still unanswered (pending)', () => {
+        const s = buildDeferredVtxoIds({ a: { status: 'pending', observedAt: 0 } }, now);
+        expect(s.has('a')).toBe(true);
+    });
+
+    it('defers a vtxo inside its "use immediately" grace window', () => {
+        const s = buildDeferredVtxoIds(
+            { a: { status: 'dismissed', observedAt: 0, deferUntil: now + 1000 } },
+            now,
+        );
+        expect(s.has('a')).toBe(true);
+    });
+
+    it('does NOT defer once the grace has lapsed (time-boxed, not permanent)', () => {
+        const s = buildDeferredVtxoIds(
+            { a: { status: 'dismissed', observedAt: 0, deferUntil: now - 1 } },
+            now,
+        );
+        expect(s.has('a')).toBe(false);
+    });
+
+    it('does NOT defer a plain dismissed entry with no grace (back-compat)', () => {
+        const s = buildDeferredVtxoIds({ a: { status: 'dismissed', observedAt: 0 } }, now);
+        expect(s.has('a')).toBe(false);
+    });
+
+    it('defers a just-observed vtxo within the 90s race window regardless of status', () => {
+        const s = buildDeferredVtxoIds(
+            { a: { status: 'refreshed', observedAt: now - 1000 } },
+            now,
+        );
+        expect(s.has('a')).toBe(true);
+    });
+
+    it('does NOT defer an old observation with no pending/grace', () => {
+        const s = buildDeferredVtxoIds(
+            { a: { status: 'refreshed', observedAt: now - RECENT_OBSERVE_WINDOW_MS - 1 } },
+            now,
+        );
+        expect(s.has('a')).toBe(false);
+    });
+
+    it('honours the full 3h grace end-to-end (deferred during, free after)', () => {
+        const deferUntil = now + SPEND_GRACE_MS; // set when "Use immediately" is tapped
+        const entry = { a: { status: 'dismissed' as const, observedAt: now, deferUntil } };
+        expect(buildDeferredVtxoIds(entry, now + SPEND_GRACE_MS - 1).has('a')).toBe(true);
+        expect(buildDeferredVtxoIds(entry, now + SPEND_GRACE_MS + 1).has('a')).toBe(false);
+    });
+
+    it('only defers the affected id in a mixed set', () => {
+        const s = buildDeferredVtxoIds(
+            {
+                grace: { status: 'dismissed', observedAt: 0, deferUntil: now + 1000 },
+                lapsed: { status: 'dismissed', observedAt: 0, deferUntil: now - 1000 },
+                done: { status: 'refreshed', observedAt: 0 },
+            },
+            now,
+        );
+        expect([...s]).toEqual(['grace']);
+    });
+
+    it('returns empty for null / empty state', () => {
+        expect(buildDeferredVtxoIds(null, now).size).toBe(0);
+        expect(buildDeferredVtxoIds({}, now).size).toBe(0);
+    });
+});


### PR DESCRIPTION
## Summary

Ark refresh-consent, swap/create resilience, and recovery UX. Single commit on top of the vc31 release.

### Refresh consent and deferral
- `refreshDeferral`: 3h "use immediately" grace with a shared auto-refresh gate
- daemon-off on the create/recover path so JS stays the sole refresh driver
- locked-in-refresh notice points the user to Capsules to cancel the round
- refresh copy and countdown precision; rescue button now reads "Rescue near-expired funds"

### Swap and create resilience
- max-swap reserve seeded to a safe holdback so Max never overshoots spendable and trips the "amount + fee > spendable" preflight
- wallet create rotates esplora providers, surviving a blockstream bot-block (the 338-byte page that surfaces as "not a blockhash")
- "incorrect mnemonic" now routes to the user-confirmed Reset and retry instead of dead-ending, unblocking the poisoned-datadir trap

### Home
- carousel rebuilds on `isArkAuth` so a recovered Ark card renders immediately instead of only after a swipe or re-navigation

## Testing
Verified on device (iPhone XR, Debug): create, Coinos to Ark swap, max swap, and delete-then-recover. `refreshDeferral` unit suite: 9/9 pass.
