### PR TITLE
docs: fix release badge + skip verify on doc-only pushes

### DIFF
--- a/.github/workflows/build-verify.yml
+++ b/.github/workflows/build-verify.yml
@@ -12,6 +12,9 @@ on:
   push:
     branches:
       - main # verify reproducibility on each release-integration push to main
+    paths-ignore: # doc-only edits do not change the build, so skip the run
+      - '**.md'
+      - 'docs/**'
   workflow_dispatch: {} # manual run for ad-hoc determinism checks
 
 # Least privilege: read the repo and nothing else. No write, no id-token, no

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ⚡ Cypher Box — A Fun Way to Play Bitcoin
 
-[![Release](https://img.shields.io/github/v/release/CypherBoxLLC/Cypher-Box?color=f7931a&label=release)](https://github.com/CypherBoxLLC/Cypher-Box/releases)
+[![Release](https://img.shields.io/badge/release-v0.1.4-f7931a)](https://github.com/CypherBoxLLC/Cypher-Box/releases)
 [![Reproducible build](https://github.com/CypherBoxLLC/Cypher-Box/actions/workflows/build-verify.yml/badge.svg)](https://github.com/CypherBoxLLC/Cypher-Box/actions/workflows/build-verify.yml)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](./LICENSE)
 [![Platform](https://img.shields.io/badge/platform-iOS%20%7C%20Android-lightgrey)](https://github.com/CypherBoxLLC/Cypher-Box/releases)


### PR DESCRIPTION
Two small fixes:

- README: the release badge used shields.io github/v/release, which is currently 503-ing and renders as a broken image. Swapped it for a static release badge that always loads (bump the version string on release).
- build-verify.yml: added paths-ignore (**.md, docs/) so doc-only pushes to main stop triggering full reproducible-build runs.

No source or build changes; release reproducibility is unaffected.