### PR TITLE
fix(unlock): close cold-start biometric bypass on the lock screen

### DIFF
--- a/UnlockWith.js
+++ b/UnlockWith.js
@@ -6,6 +6,7 @@ import { SafeAreaView } from 'react-native-safe-area-context';
 import { StackActions, useNavigation, useRoute } from '@react-navigation/native';
 import { BlueStorageContext } from './blue_modules/storage-context';
 import { isHandset } from './blue_modules/environment';
+import { resolveUnlockAction } from './blue_modules/unlockDecision';
 import triggerHapticFeedback, { HapticFeedbackTypes } from './blue_modules/hapticFeedback';
 
 const styles = StyleSheet.create({
@@ -121,9 +122,17 @@ const UnlockWith = () => {
       }
 
       setBiometricType(bt);
-      if (!biometricType || storageIsEncrypted) {
+      // Decide from the freshly fetched `bt`, never from the `biometricType`
+      // state variable: state updates do not apply inside this closure, so
+      // reading state here always saw the initial `false` and silently took
+      // the no-auth key path on cold start (biometrics enabled, storage
+      // unencrypted). See tests/unit/unlockDecision.test.ts.
+      const action = resolveUnlockAction(bt, storageIsEncrypted);
+      if (action === 'key') {
         unlockWithKey();
-      } else if (typeof biometricType === 'string') unlockWithBiometrics();
+      } else {
+        unlockWithBiometrics();
+      }
     }
   };
 

--- a/blue_modules/unlockDecision.ts
+++ b/blue_modules/unlockDecision.ts
@@ -1,0 +1,17 @@
+/**
+ * Pure decision for which unlock path the app should take on the lock screen.
+ *
+ * Extracted from UnlockWith.js so the policy is unit-testable. The previous
+ * implementation branched on React state (`biometricType`) that was still
+ * `false` on the first render, which made the biometric branch unreachable
+ * on cold start and silently self-unlocked the app with no authentication
+ * for users who had biometrics enabled but storage encryption off.
+ */
+export type UnlockAction = 'key' | 'biometrics';
+
+export function resolveUnlockAction(biometricType: boolean | string, storageIsEncrypted: boolean): UnlockAction {
+  if (!biometricType || storageIsEncrypted) {
+    return 'key';
+  }
+  return 'biometrics';
+}

--- a/tests/unit/unlockDecision.test.ts
+++ b/tests/unit/unlockDecision.test.ts
@@ -1,0 +1,26 @@
+import { resolveUnlockAction } from '../../blue_modules/unlockDecision';
+
+describe('resolveUnlockAction', () => {
+  it('uses biometrics when biometrics are enabled and storage is not encrypted', () => {
+    expect(resolveUnlockAction('Biometrics', false)).toBe('biometrics');
+    expect(resolveUnlockAction('Face ID', false)).toBe('biometrics');
+    expect(resolveUnlockAction('Touch ID', false)).toBe('biometrics');
+  });
+
+  it('falls back to the key (password) path when storage is encrypted', () => {
+    expect(resolveUnlockAction('Biometrics', true)).toBe('key');
+    expect(resolveUnlockAction('Face ID', true)).toBe('key');
+  });
+
+  it('falls back to the key path when biometrics are unavailable or disabled', () => {
+    expect(resolveUnlockAction(false, false)).toBe('key');
+    expect(resolveUnlockAction(false, true)).toBe('key');
+  });
+
+  it('never returns biometrics for a falsy biometric type (cold-start regression)', () => {
+    // On cold start the freshly fetched capability value must drive the
+    // decision; a stale falsy value must force the key path, never an
+    // unauthenticated self-unlock.
+    expect(resolveUnlockAction(false, false)).not.toBe('biometrics');
+  });
+});


### PR DESCRIPTION
## Problem

Found in an independent security review of the app (happy to share the full report).

`UnlockWith.startUnlock()` decided which unlock path to take by reading the `biometricType` **React state variable** inside the same closure that had just called `setBiometricType(bt)`. State updates do not apply inside the running closure, so `biometricType` was still its initial value `false` at decision time:

```js
setBiometricType(bt);
if (!biometricType || storageIsEncrypted) {   // always true on cold start
  unlockWithKey();                             // no-auth path
} else if (typeof biometricType === 'string') unlockWithBiometrics();  // unreachable
```

**Impact:** for a user with biometrics enabled but storage encryption off (the default), a cold app start ran `unlockWithKey()` → `startAndDecrypt()` → wallets load with **zero authentication**. The biometric lock screen appeared to be on while doing nothing on cold start.

## Fix

Decide from the freshly fetched `bt` value, via a small pure helper (`blue_modules/unlockDecision.ts`) so the policy is unit-testable. No behavior change except restoring the intended biometric gate.

## Test

- New `tests/unit/unlockDecision.test.ts` covers all four capability/encryption combinations, including the cold-start regression case (a stale falsy value must never select the biometric path).

## Severity

HIGH — authentication control silently inoperative for the default configuration. Recommend shipping in the next release.