### PR TITLE
fix(privacy): re-wire screen-capture shield; auto-clear sensitive clipboard copies

### DIFF
--- a/BlueComponents.js
+++ b/BlueComponents.js
@@ -21,6 +21,7 @@ import {
   ImageBackground,
 } from 'react-native';
 import Clipboard from '@react-native-clipboard/clipboard';
+import { copySensitiveToClipboard } from './helpers/clipboardSensitive';
 import NetworkTransactionFees, { NetworkTransactionFee, NetworkTransactionFeeType } from './models/networkTransactionFees';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { BlueCurrentTheme, useTheme } from './components/themes';
@@ -265,11 +266,13 @@ export class BlueCopyTextToClipboard extends Component {
   static propTypes = {
     text: PropTypes.string,
     truncated: PropTypes.bool,
+    sensitive: PropTypes.bool,
   };
 
   static defaultProps = {
     text: '',
     truncated: false,
+    sensitive: false,
   };
 
   constructor(props) {
@@ -287,7 +290,11 @@ export class BlueCopyTextToClipboard extends Component {
 
   copyToClipboard = () => {
     this.setState({ hasTappedText: true }, () => {
-      Clipboard.setString(this.props.text);
+      if (this.props.sensitive) {
+        copySensitiveToClipboard(this.props.text);
+      } else {
+        Clipboard.setString(this.props.text);
+      }
       this.setState({ address: loc.wallets.xpub_copiedToClipboard }, () => {
         setTimeout(() => {
           this.setState({ hasTappedText: false, address: this.props.text });

--- a/blue_modules/Privacy.android.tsx
+++ b/blue_modules/Privacy.android.tsx
@@ -2,8 +2,10 @@ import { useContext, useEffect } from 'react';
 // @ts-ignore: react-native-obscure is not in the type definition
 import Obscure from 'react-native-obscure';
 import { BlueStorageContext } from './storage-context';
+import { isPrivacyBlurOn, setPrivacyBlurMasterSwitch } from './privacySetting';
+
 interface PrivacyComponent extends React.FC {
-  enableBlur: (isPrivacyBlurEnabled: boolean) => void;
+  enableBlur: () => void;
   disableBlur: () => void;
 }
 
@@ -11,14 +13,20 @@ const Privacy: PrivacyComponent = () => {
   const { isPrivacyBlurEnabled } = useContext(BlueStorageContext);
 
   useEffect(() => {
-    Obscure.deactivateObscure();
+    setPrivacyBlurMasterSwitch(isPrivacyBlurEnabled);
+    if (!isPrivacyBlurEnabled) {
+      // Turning the setting off must take effect immediately. Turning it on
+      // does not force-activate globally: screens opt in on focus via
+      // Privacy.enableBlur().
+      Obscure.deactivateObscure();
+    }
   }, [isPrivacyBlurEnabled]);
 
   return null;
 };
 
-Privacy.enableBlur = (isPrivacyBlurEnabled: boolean) => {
-  if (!isPrivacyBlurEnabled) return;
+Privacy.enableBlur = () => {
+  if (!isPrivacyBlurOn()) return;
   Obscure.activateObscure();
 };
 

--- a/blue_modules/Privacy.ios.tsx
+++ b/blue_modules/Privacy.ios.tsx
@@ -2,9 +2,10 @@ import { useContext, useEffect } from 'react';
 // @ts-ignore: react-native-obscure is not in the type definition
 import { enabled } from 'react-native-privacy-snapshot';
 import { BlueStorageContext } from './storage-context';
+import { isPrivacyBlurOn, setPrivacyBlurMasterSwitch } from './privacySetting';
 
 interface PrivacyComponent extends React.FC {
-  enableBlur: (isPrivacyBlurEnabled: boolean) => void;
+  enableBlur: () => void;
   disableBlur: () => void;
 }
 
@@ -12,14 +13,20 @@ const Privacy: PrivacyComponent = () => {
   const { isPrivacyBlurEnabled } = useContext(BlueStorageContext);
 
   useEffect(() => {
-    Privacy.disableBlur();
+    setPrivacyBlurMasterSwitch(isPrivacyBlurEnabled);
+    if (!isPrivacyBlurEnabled) {
+      // Turning the setting off must take effect immediately. Turning it on
+      // does not force-activate globally: screens opt in on focus via
+      // Privacy.enableBlur().
+      Privacy.disableBlur();
+    }
   }, [isPrivacyBlurEnabled]);
 
   return null;
 };
 
-Privacy.enableBlur = (isPrivacyBlurEnabled: boolean) => {
-  if (!isPrivacyBlurEnabled) return;
+Privacy.enableBlur = () => {
+  if (!isPrivacyBlurOn()) return;
   enabled(true);
 };
 

--- a/blue_modules/privacySetting.ts
+++ b/blue_modules/privacySetting.ts
@@ -1,0 +1,18 @@
+/**
+ * Module-level master switch for the screen-capture shield (FLAG_SECURE on
+ * Android, privacy-snapshot on iOS).
+ *
+ * The <Privacy/> component (mounted once in App.js) syncs this from
+ * BlueStorageContext. The platform Privacy components' static
+ * enableBlur/disableBlur helpers read it, so screens can opt into the shield
+ * on focus without threading context through every call site.
+ */
+let privacyBlurMasterSwitch = true;
+
+export function setPrivacyBlurMasterSwitch(value: boolean): void {
+  privacyBlurMasterSwitch = value;
+}
+
+export function isPrivacyBlurOn(): boolean {
+  return privacyBlurMasterSwitch;
+}

--- a/helpers/clipboardSensitive.ts
+++ b/helpers/clipboardSensitive.ts
@@ -1,0 +1,28 @@
+import Clipboard from '@react-native-clipboard/clipboard';
+
+/**
+ * Sensitive clipboard copy with best-effort auto-clear.
+ *
+ * Seed phrases and private keys copied to the system clipboard would
+ * otherwise persist there indefinitely, readable by any other app on the
+ * device. After `clearAfterMs` we clear the clipboard, but only if it still
+ * holds exactly what we put there (never clobber the user's later copies).
+ * iOS 14+ additionally shows a paste notification to the user; the clear is
+ * best-effort on both platforms since another app may have read it already.
+ */
+const DEFAULT_CLEAR_AFTER_MS = 60000;
+
+export function copySensitiveToClipboard(text: string, clearAfterMs: number = DEFAULT_CLEAR_AFTER_MS): void {
+  Clipboard.setString(text);
+  setTimeout(() => {
+    Clipboard.getString()
+      .then(current => {
+        if (current === text) {
+          Clipboard.setString('');
+        }
+      })
+      .catch(() => {
+        // best-effort only; never throw from a timer
+      });
+  }, clearAfterMs);
+}

--- a/screen/wallets/export.js
+++ b/screen/wallets/export.js
@@ -115,7 +115,7 @@ const WalletExport = () => {
             )}
             <BlueSpacing20 />
             {wallet.type === LightningCustodianWallet.type || wallet.type === WatchOnlyWallet.type ? (
-              <BlueCopyTextToClipboard text={wallet.getSecret()} />
+              <BlueCopyTextToClipboard text={wallet.getSecret()} sensitive />
             ) : (
               <BlueText style={[styles.secret, styles.secretWritingDirection, stylesHook.secret]} testID="Secret">
                 {wallet.getSecret()}

--- a/screen/wallets/pleaseBackupLNDHub.js
+++ b/screen/wallets/pleaseBackupLNDHub.js
@@ -61,7 +61,7 @@ const PleaseBackupLNDHub = () => {
         </View>
         <BlueSpacing20 />
         <QRCodeComponent value={wallet.getSecret()} size={qrCodeSize} />
-        <BlueCopyTextToClipboard text={wallet.getSecret()} />
+        <BlueCopyTextToClipboard text={wallet.getSecret()} sensitive />
         <BlueSpacing20 />
         <Button onPress={pop} title={loc.pleasebackup.ok_lnd} />
       </ScrollView>

--- a/screen/wallets/pleaseBackupLdk.js
+++ b/screen/wallets/pleaseBackupLdk.js
@@ -71,7 +71,7 @@ const PleaseBackupLdk = () => {
             ecl="H"
           />
         </View>
-        <BlueCopyTextToClipboard text={wallet.getSecret()} />
+        <BlueCopyTextToClipboard text={wallet.getSecret()} sensitive />
         <BlueSpacing20 />
         <Button onPress={pop} title={loc.pleasebackup.ok_lnd} />
       </ScrollView>

--- a/tests/unit/privacySetting.test.ts
+++ b/tests/unit/privacySetting.test.ts
@@ -1,0 +1,14 @@
+import { isPrivacyBlurOn, setPrivacyBlurMasterSwitch } from '../../blue_modules/privacySetting';
+
+describe('privacySetting master switch', () => {
+  it('defaults to on', () => {
+    expect(isPrivacyBlurOn()).toBe(true);
+  });
+
+  it('reflects updates from the <Privacy/> sync effect', () => {
+    setPrivacyBlurMasterSwitch(false);
+    expect(isPrivacyBlurOn()).toBe(false);
+    setPrivacyBlurMasterSwitch(true);
+    expect(isPrivacyBlurOn()).toBe(true);
+  });
+});


### PR DESCRIPTION
## Problem

Found in an independent security review (full report available on request).

Two related privacy defects on seed/secret screens:

1. **The screen-capture shield is inert app-wide.** All 14 call sites invoke `Privacy.enableBlur()` with no argument, but the Android and iOS implementations early-return unless passed a truthy `isPrivacyBlurEnabled` — so `Obscure.activateObscure()` / `privacy-snapshot` **never activate**, despite the setting defaulting to ON. The mounted `<Privacy/>` component additionally only ever *deactivates* on setting changes.

2. **Seed phrases copied to the clipboard persist indefinitely.** `BlueCopyTextToClipboard` on the three seed-export screens copies the raw secret with no auto-clear and no warning; any other app can read the clipboard afterwards.

## Fix

- `enableBlur()` / `disableBlur()` now take no argument. The master setting is synced to a module-level switch by the mounted `<Privacy/>` component (App.js), so all 14 existing call sites work exactly as written. Turning the setting off takes effect immediately; turning it on lets screens opt in on focus (unchanged semantics, now actually functioning).
- `BlueCopyTextToClipboard` gains a `sensitive` prop: copies auto-clear after 60s, and only if the clipboard still holds the copied value (never clobbers the user's later copies). Wired on the three seed-export screens (`export.js`, `pleaseBackupLdk.js`, `pleaseBackupLNDHub.js`).

## Test

- New `tests/unit/privacySetting.test.ts` covers the master-switch sync.
- Manual: open a seed export screen → background the app → app-switcher preview should be obscured (Android) / blanked (iOS) when the setting is on; copy a seed → clipboard clears itself within 60s.