### PR TITLE
docs(security): keystore rotation runbook + relay/OAuth hardening + root-detection policy

### DIFF
--- a/docs/security/KEYSTORE-ROTATION-RUNBOOK.md
+++ b/docs/security/KEYSTORE-ROTATION-RUNBOOK.md
@@ -1,0 +1,72 @@
+# Keystore Rotation Runbook (CRITICAL — do first)
+
+**Why:** two Android signing keystores and their plaintext passwords were committed
+to this public repository's history and remain retrievable by anyone. Deleting them
+from the working tree (commit `73f086a`) did **not** remove them from history:
+
+- Blobs `5663d6dd` and `872c6bfb` (both PKCS#12 keystores, ~2.7 KB each)
+- `android/gradle.properties` history shows `MYAPP_RELEASE_STORE_PASSWORD=Cypherbox`
+  (and a second password `CypherBox2026` per the same history)
+
+Until disproven, treat both keystores and both passwords as compromised.
+
+## 1. Rotate the Play upload key (owner action, ~30 min)
+
+1. Play Console → **Release → Setup → App integrity → Upload key certificate**.
+2. **Request upload key reset** (Google support flow; typically approved in 1–2 days).
+3. Generate the replacement locally, never in CI output or a tracked path:
+   ```bash
+   keytool -genkeypair -v -keystore ~/cypherbox-keystores/cypherbox-upload-2026.keystore \
+     -alias upload -keyalg RSA -keysize 4096 -validity 10950
+   ```
+4. Export the PEM certificate and upload it to the reset request:
+   ```bash
+   keytool -export -rfc -keystore ~/cypherbox-keystores/cypherbox-upload-2026.keystore \
+     -alias upload -file upload_certificate.pem
+   ```
+5. Store the new keystore + passwords in the team password manager. The keystore
+   and its passwords must never be committed, echoed, or placed in CI artifacts.
+
+## 2. Rotate every adjacent secret
+
+- GitHub repo secrets `KEYSTORE_FILE_HEX` / `KEYSTORE_PASSWORD` (used by the release
+  flow) → regenerate from the NEW keystore only after step 1 completes.
+- The passwords `Cypherbox` / `CypherBox2026`: change them **everywhere they were
+  reused** (keystores, stores, accounts). Password reuse is the usual escalation path.
+
+## 3. Purge the keystores from git history
+
+History rewrite requires a coordinated force-push. All contributors must re-clone
+or hard-reset afterwards.
+
+```bash
+# Mirror-clone, then use BFG (https://rtyley.github.io/bfg-repo-cleaner/)
+git clone --mirror git@github.com:CypherBoxLLC/Cypher-Box.git
+bfg --delete-files 'cypherbox-release.keystore' Cypher-Box.git
+bfg --delete-files 'my-release-key.keystore' Cypher-Box.git
+# Scrub the passwords from every historical text file
+bfg --replace-text <(printf 'Cypherbox==>REMOVED\nCypherBox2026==>REMOVED\n') Cypher-Box.git
+cd Cypher-Box.git && git reflog expire --expire=now --all && git gc --prune=now --aggressive
+git push --force
+```
+
+Then ask GitHub support to drop cached views of the pre-purge commits, and treat any
+fork as still carrying the secrets (rotation in steps 1–2 is what actually closes the
+exposure; the purge is hygiene).
+
+## 4. Prevent recurrence
+
+- `.gitignore` already covers `*.jks` / `keystore.properties` — verify it also covers
+  `*.keystore` (any name), and keep it that way.
+- The PR gitleaks gate should additionally scan for keystore magic bytes; consider
+  pinning the gitleaks config to the base branch (see companion finding on the
+  gate reading config from the PR's own checkout).
+- Local keystores live only in `~/cypherbox-keystores/` (already your convention) —
+  that path must stay outside any repo.
+
+## Verification when done
+
+- Play Console shows the new upload key certificate fingerprint.
+- `git log --all -p -- android/gradle.properties | grep -i password` finds nothing
+  post-purge; `git cat-file -t 5663d6dd` errors (object gone).
+- A fresh clone contains no keystore blobs: `git rev-list --objects --all | grep -i keystore`.

--- a/docs/security/RELAY-AND-OAUTH-HARDENING.md
+++ b/docs/security/RELAY-AND-OAUTH-HARDENING.md
@@ -1,0 +1,55 @@
+# Relay & OAuth Hardening Design Notes
+
+Findings from the 2026-07 security review that need **server-side or design
+decisions**, not just client patches. Client PRs should wait for these decisions.
+
+## 1. Stop storing live CoinOS session tokens on the relay (RB-NET-07)
+
+**Today:** `src/services/coinosSocket.ts` `registerPushToken()` POSTs
+`{ username, coinosToken, pushToken }` to `notifications.cypherbox.io:3002/register`.
+The relay keeps the user's money-moving CoinOS session token in SQLite so it can
+watch for incoming payments and push them.
+
+**Risk:** relay/VPS/SQLite compromise = full custodial account access for every
+registered user. A self-hosted Express+SQLite box is a much softer target than
+CoinOS itself.
+
+**Options (pick one):**
+- **A. Scoped watch credential (preferred).** CoinOS issues (or you derive) a
+  read-only/watch-only credential — e.g. an LNbits-style `inkey` (invoice/read key)
+  instead of the admin key, or a per-user webhook registration. The relay stores a
+  credential that can observe payments but cannot spend.
+- **B. Nostr/watch-only subscription.** Watch the user's public payment identifier
+  (zap address / LNURL-pay static code) — no bearer token leaves the device at all.
+- **C. Keep tokens, harden the relay.** If tokens must stay server-side: encrypt at
+  rest with a key outside the box, bind tokens to device + expiry, rotate on push
+  token change, and publish the relay source for review. Weakest option; document as
+  accepted risk in SECURITY.md if chosen.
+
+Whichever option ships, the client change (drop `coinosToken` from the register
+payload) lands in the same release as the server change — they are one rollout.
+
+## 2. The relay API key is public-by-design (RB-NET-06)
+
+`RELAY_API_KEY` lives in the gitignored `blue_modules/secrets.ts`, which is bundled
+into every distributed build. Any user can extract it from the APK. That is fine **if
+the server treats it as an app-traffic filter, not authorization**: the relay must not
+trust any payload merely because it carries the key. Per-user rate limits, payload
+validation, and no admin endpoints behind the shared key. (The previous hardcoded
+value was already leaked once in git history and rotated — good response; the design
+note above is what makes the next leak a non-event.)
+
+## 3. Strike OAuth exchange should not transit a proxy (RB-NET-05)
+
+`src/screens/CheckingAccountLogin/index.tsx` sends the PKCE `code` + `verifier` to
+`https://cypherbox-backend.onrender.com/oauth/start`, which performs the token
+exchange. Whoever operates that proxy (and its host) can observe the exchange and
+mint the money-moving access token. The proxy's code is not in this repo and is
+currently unauditable.
+
+**Preferred:** perform the exchange on-device. PKCE exists precisely so public
+clients can exchange codes without a secret — Strike's token endpoint should accept
+the exchange directly from the app. If Strike requires a confidential client (the
+only legitimate reason for the proxy), then: publish the proxy source, pin it under
+your own domain, log nothing at the token endpoint, and state the trust decision in
+SECURITY.md so users know a first-party server observes token mint.

--- a/docs/security/ROOT-DETECTION-POLICY.md
+++ b/docs/security/ROOT-DETECTION-POLICY.md
@@ -1,0 +1,20 @@
+# Root / Jailbreak / Tamper Detection — Policy Decision Needed
+
+**Finding (MEDIUM, MASVS-RESILIENCE-1):** the app ships with **no** root, jailbreak,
+tamper, emulator, or Play Integrity detection, and SECURITY.md documents no accepted
+risk. For a self-custody wallet holding hot Ark and on-chain seeds, several audit
+findings get worse on a rooted device (the MMKV-at-rest findings and the
+no-attempt-throttle finding especially).
+
+This is a product-policy decision, not a bug with one right fix. Options:
+
+| Option | What it means | Trade-off |
+|---|---|---|
+| **A. Hard block** | Refuse to run on rooted/jailbroken devices (Play Integrity API + jailbreak checks) | Best protection for average users; locks out power users, custom-ROM users, and some threat-model-driven users who root *for* security |
+| **B. Warn-and-continue (common for wallets)** | Detect root/jailbreak, show a prominent one-time warning that device integrity is compromised and hot-wallet funds are at higher risk, let the user continue | Respects sovereignty; converts a silent risk into an informed one |
+| **C. Documented accepted risk** | No detection; SECURITY.md states that device integrity is the user's responsibility | Zero code; weakest posture, but honest |
+
+**Recommendation:** B for the hot custodial balances (CoinOS/Strike) and A-or-B for
+seed-bearing wallets, implemented behind Play Integrity on Android and jailbreak
+detection on iOS. Whichever option is chosen, record it in SECURITY.md so the posture
+is a decision, not an omission.


### PR DESCRIPTION
Response documentation for the 2026-07 independent security review (full report available on request).

## Contents

1. **`docs/security/KEYSTORE-ROTATION-RUNBOOK.md`** — **CRITICAL, do first.** Two Android signing keystores and their plaintext passwords were committed to this repo's public history and remain retrievable (blobs `5663d6dd`/`872c6bfb`; `gradle.properties` history shows `MYAPP_RELEASE_STORE_PASSWORD=Cypherbox`). Tree-removal in `73f086a` did not purge history. The runbook covers: Play Console upload-key reset, rotating `KEYSTORE_FILE_HEX`/`KEYSTORE_PASSWORD` and any reused passwords, BFG history purge with verification, and recurrence prevention. **Rotation is the fix; the purge is hygiene — do rotation even if the purge is delayed.**

2. **`docs/security/RELAY-AND-OAUTH-HARDENING.md`** — design decisions before client PRs: (a) the relay currently stores users' **live CoinOS session tokens** in SQLite (options: scoped watch credential, watch-only subscription, or harden+publish); (b) the shared relay API key is extractable from every distributed build — the server must treat it as a traffic filter, not authorization; (c) the Strike PKCE exchange currently transits an unaudited proxy that observes token mint — prefer on-device exchange (PKCE is designed for public clients).

3. **`docs/security/ROOT-DETECTION-POLICY.md`** — decision framework for root/jailbreak/tamper detection (hard-block vs warn-and-continue vs documented accepted risk), with a recommendation for a self-custody wallet.

Docs-only; no code changes.