### PR TITLE
fix(send): verify LNURL-pay invoices + payjoin endpoints on custodial sends

### DIFF
--- a/class/deeplink-schema-match.js
+++ b/class/deeplink-schema-match.js
@@ -491,7 +491,14 @@ class DeeplinkSchemaMatch {
           memo = parsedBitcoinUri.options.label || memo;
         }
         if ('pj' in parsedBitcoinUri.options) {
-          payjoinUrl = parsedBitcoinUri.options.pj;
+          const pjCandidate = parsedBitcoinUri.options.pj;
+          // BIP78: the payjoin endpoint must be HTTPS (HTTP only for .onion,
+          // which this build does not support). A cleartext or non-HTTP pj=
+          // endpoint would receive the PSBT in the clear, so drop it here and
+          // fall back to a normal (non-payjoin) send.
+          if (typeof pjCandidate === 'string' && /^https:\/\/.+/.test(pjCandidate)) {
+            payjoinUrl = pjCandidate;
+          }
         }
       }
     } catch (_) { }

--- a/src/api/coinOSApis.ts
+++ b/src/api/coinOSApis.ts
@@ -4,6 +4,7 @@ import AsyncStorage from "@react-native-async-storage/async-storage";
 
 import { updateExchangeRate, EXCHANGE_RATES_STORAGE_KEY } from "../../blue_modules/currency";
 import { getFiatRate } from "../../models/fiatUnit";
+import { assertLnurlPayCallbackUrl, assertAmountWithinSendable, buildCallbackUrl, verifyLnurlPayInvoice } from "./lnurlPayValidation";
 
 const BASE_URL = 'https://coinos.io/api';
 
@@ -310,14 +311,21 @@ export const sendCoinsViaUsername = async (address: string, amount: number, memo
     }
 
     let url = `https://${domain}/.well-known/lnurlp/${name}`;
-    
+
     const response = await fetch(url);
 if (__DEV__) console.log('sendCoinsViaLNURL response: ', response)
     const lnurlPayData = await response.json();
 if (__DEV__) console.log('sendCoinsViaLNURL lnurlPayData: ', lnurlPayData)
 
     if (lnurlPayData.tag === "payRequest") {
-      const paymentResponse = await fetch(lnurlPayData.callback+'?amount='+(amount * 1000), {
+      // Verify the service before trusting anything it returns: https-only
+      // callback, declared min/max bounds, then verify the returned invoice
+      // matches the amount the user confirmed and commits to the service
+      // metadata (same checks as the hardened class/lnurl.js path).
+      assertLnurlPayCallbackUrl(lnurlPayData.callback);
+      const amountMsat = Math.floor(amount * 1000);
+      assertAmountWithinSendable(amountMsat, lnurlPayData.minSendable, lnurlPayData.maxSendable);
+      const paymentResponse = await fetch(buildCallbackUrl(lnurlPayData.callback, amountMsat), {
         method: "GET",
         headers: {
           "Content-Type": "application/json",
@@ -328,6 +336,7 @@ if (__DEV__) console.log('sendCoinsViaLNURL paymentResponse: ', paymentResponse)
       const paymentResult = await paymentResponse.json();
 if (__DEV__) console.log('sendCoinsViaLNURL paymentResult: ', paymentResult)
       if(paymentResult.pr){
+        verifyLnurlPayInvoice(paymentResult.pr, amount, lnurlPayData.metadata);
 if (__DEV__) console.log('domain: ', domain)
         if(domain == 'coinos.io'){
           const response = await fetch(`${BASE_URL}/payments`, await withAuthToken({

--- a/src/api/lnurlPayValidation.ts
+++ b/src/api/lnurlPayValidation.ts
@@ -1,0 +1,72 @@
+/**
+ * LNURL-pay response validation for custodial send paths.
+ *
+ * The CoinOS username-send flow previously paid whatever invoice the remote
+ * service returned with no verification. These helpers enforce the same
+ * checks the hardened class/lnurl.js path performs (callback scheme,
+ * min/max sendable bounds, invoice amount, metadata description_hash), so a
+ * malicious or compromised LNURL service cannot swap amounts, descriptions,
+ * or downgrade to cleartext.
+ */
+import bolt11 from 'bolt11';
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const createHash = require('create-hash');
+
+/** LNURL-pay callbacks must be HTTPS (or HTTP only for .onion, per LUD-16). */
+export function assertLnurlPayCallbackUrl(callback: unknown): asserts callback is string {
+  if (typeof callback !== 'string' || callback.length === 0) {
+    throw new Error('LNURL-pay response has no callback URL');
+  }
+  let parsed: URL;
+  try {
+    parsed = new URL(callback);
+  } catch (_) {
+    throw new Error('LNURL-pay callback is not a valid URL');
+  }
+  const isOnion = parsed.hostname.endsWith('.onion');
+  if (parsed.protocol === 'https:') return;
+  if (parsed.protocol === 'http:' && isOnion) return;
+  throw new Error('LNURL-pay callback must be https (http only allowed for .onion)');
+}
+
+/** Enforce the service's declared min/max sendable bounds (msats). */
+export function assertAmountWithinSendable(amountMsat: number, minSendable?: number, maxSendable?: number): void {
+  if (typeof minSendable === 'number' && amountMsat < minSendable) {
+    throw new Error(`Amount ${amountMsat} msat is below the service minimum of ${minSendable} msat`);
+  }
+  if (typeof maxSendable === 'number' && amountMsat > maxSendable) {
+    throw new Error(`Amount ${amountMsat} msat is above the service maximum of ${maxSendable} msat`);
+  }
+}
+
+/**
+ * Verify the returned bolt11 invoice actually matches what the user asked
+ * to pay: same amount, and (when the service supplied metadata) the
+ * invoice's description_hash commits to that exact metadata.
+ */
+export function verifyLnurlPayInvoice(pr: string, expectedAmountSats: number, metadata?: string): void {
+  const decoded = bolt11.decode(pr);
+  const invoiceSats =
+    typeof decoded.satoshis === 'number'
+      ? decoded.satoshis
+      : decoded.millisatoshis
+        ? Math.round(Number(decoded.millisatoshis) / 1000)
+        : 0;
+  if (invoiceSats !== Math.round(expectedAmountSats)) {
+    throw new Error(`Invoice doesn't match specified amount, got ${invoiceSats}, expected ${Math.round(expectedAmountSats)}`);
+  }
+  if (metadata) {
+    const metadataHash = createHash('sha256').update(metadata).digest('hex');
+    const invoiceHash = decoded.tagsObject.purpose_commit_hash;
+    if (invoiceHash !== metadataHash) {
+      throw new Error("Invoice description_hash doesn't match metadata.");
+    }
+  }
+}
+
+/** Correctly join the amount parameter onto a callback that may already have a query string. */
+export function buildCallbackUrl(callback: string, amountMsat: number): string {
+  const separator = callback.indexOf('?') === -1 ? '?' : '&';
+  return `${callback}${separator}amount=${Math.floor(amountMsat)}`;
+}

--- a/tests/unit/deeplink-schema-match.test.js
+++ b/tests/unit/deeplink-schema-match.test.js
@@ -412,6 +412,27 @@ describe.each(['', '//'])('unit - DeepLinkSchemaMatch', function (suffix) {
     );
   });
 
+  it('decodeBitcoinUri drops non-https payjoin endpoints (BIP78)', () => {
+    // cleartext http pj= must be dropped: the endpoint receives the PSBT
+    const decoded = DeeplinkSchemaMatch.decodeBitcoinUri(
+      `bitcoin:${suffix}bc1qnapskphjnwzw2w3dk4anpxntunc77v6qrua0f7?amount=0.0001&pj=http://btc.donate.kukks.org/BTC/pj`,
+    );
+    assert.strictEqual(decoded.payjoinUrl, '');
+    assert.strictEqual(decoded.address, 'bc1qnapskphjnwzw2w3dk4anpxntunc77v6qrua0f7');
+
+    // non-URL pj= must be dropped as well
+    const decoded2 = DeeplinkSchemaMatch.decodeBitcoinUri(
+      `bitcoin:${suffix}bc1qnapskphjnwzw2w3dk4anpxntunc77v6qrua0f7?amount=0.0001&pj=notaurl`,
+    );
+    assert.strictEqual(decoded2.payjoinUrl, '');
+
+    // https is preserved
+    const decoded3 = DeeplinkSchemaMatch.decodeBitcoinUri(
+      `bitcoin:${suffix}bc1qnapskphjnwzw2w3dk4anpxntunc77v6qrua0f7?amount=0.0001&pj=https://btc.donate.kukks.org/BTC/pj`,
+    );
+    assert.strictEqual(decoded3.payjoinUrl, 'https://btc.donate.kukks.org/BTC/pj');
+  });
+
   it('recognizes files', () => {
     // txn files:
     assert.ok(DeeplinkSchemaMatch.isTXNFile('file://com.android.externalstorage.documents/document/081D-1403%3Atxhex.txn'));

--- a/tests/unit/lnurlPayValidation.test.ts
+++ b/tests/unit/lnurlPayValidation.test.ts
@@ -1,0 +1,72 @@
+import assert from 'assert';
+import {
+  assertLnurlPayCallbackUrl,
+  assertAmountWithinSendable,
+  buildCallbackUrl,
+  verifyLnurlPayInvoice,
+} from '../../src/api/lnurlPayValidation';
+
+// Real 10-sat invoice whose description_hash commits to the metadata below
+// (same fixture as tests/unit/lnurl.test.js).
+const VALID_PR =
+  'lnbc100n1psj8g53pp50t7xmnvnzsm6y78kcvqqudlnnushc04sevtneessp463ndpf83qshp5nh0t5w4w5zh8jdnn5a03hk4pk279l3eex4nzazgkwmqpn7wga6hqcqzpgxqr23ssp5ddpxstde98ekccnvzms67h9uflxmpj939aj4rwc5xwru0x6nfkus9qyyssq55n5hn9gwmrzx2ekajlqshvu53u8h3p0npu7ng4d0lnttgueprzr4mtpwa83jrpz4skhdx3p0xnh9jc92ysnu8umuwa70hkxhp44svsq9u5uqr';
+const VALID_METADATA = '[["text/plain","Comment on lnurl-pay chat 📝"]]';
+
+describe('assertLnurlPayCallbackUrl', () => {
+  it('accepts https callbacks', () => {
+    assertLnurlPayCallbackUrl('https://lntxbot.bigsun.xyz/lnurl/pay/callback?userid=7116');
+  });
+
+  it('accepts http only for .onion', () => {
+    assertLnurlPayCallbackUrl('http://hidden6j4bnxq.onion/lnurlp/callback');
+  });
+
+  it('rejects cleartext http callbacks', () => {
+    assert.throws(() => assertLnurlPayCallbackUrl('http://example.com/callback'), /https/);
+  });
+
+  it('rejects non-http(s) schemes and garbage', () => {
+    assert.throws(() => assertLnurlPayCallbackUrl('ftp://example.com/cb'));
+    assert.throws(() => assertLnurlPayCallbackUrl('not a url'));
+    assert.throws(() => assertLnurlPayCallbackUrl(''));
+    assert.throws(() => assertLnurlPayCallbackUrl(undefined));
+  });
+});
+
+describe('assertAmountWithinSendable', () => {
+  it('enforces min and max when declared', () => {
+    assertAmountWithinSendable(10000, 1000, 1000000000);
+    assert.throws(() => assertAmountWithinSendable(999, 1000, undefined), /minimum/);
+    assert.throws(() => assertAmountWithinSendable(1000000001, undefined, 1000000000), /maximum/);
+  });
+
+  it('passes when bounds are absent', () => {
+    assertAmountWithinSendable(1);
+  });
+});
+
+describe('buildCallbackUrl', () => {
+  it('uses ? for a bare callback and & when a query already exists', () => {
+    assert.strictEqual(buildCallbackUrl('https://x.io/cb', 10000), 'https://x.io/cb?amount=10000');
+    assert.strictEqual(buildCallbackUrl('https://x.io/cb?userid=7', 10000), 'https://x.io/cb?userid=7&amount=10000');
+  });
+});
+
+describe('verifyLnurlPayInvoice', () => {
+  it('accepts an invoice matching amount and metadata', () => {
+    verifyLnurlPayInvoice(VALID_PR, 10, VALID_METADATA);
+  });
+
+  it('rejects an amount mismatch', () => {
+    assert.throws(() => verifyLnurlPayInvoice(VALID_PR, 11, VALID_METADATA), /doesn't match specified amount/);
+  });
+
+  it('rejects a metadata (description_hash) mismatch', () => {
+    assert.throws(() => verifyLnurlPayInvoice(VALID_PR, 10, '[["text/plain","different"]]'), /description_hash/);
+  });
+
+  it('still enforces amount when metadata is absent', () => {
+    verifyLnurlPayInvoice(VALID_PR, 10);
+    assert.throws(() => verifyLnurlPayInvoice(VALID_PR, 9), /doesn't match specified amount/);
+  });
+});


### PR DESCRIPTION
## Problem

From the 2026-07 independent security review (full report available on request).

**`sendCoinsViaUsername()`** (`src/api/coinOSApis.ts`) implements a parallel LNURL-pay flow that pays the returned bolt11 invoice **with no verification at all**:

- the callback URL is used verbatim — a cleartext `http://` callback is fetched (MITM invoice swap);
- the service's declared `minSendable`/`maxSendable` bounds are ignored;
- the returned invoice's amount is never compared to what the user confirmed;
- the invoice's `description_hash` is never bound to the service metadata (recipient/description substitution).

The app already has a hardened implementation of exactly these checks in `class/lnurl.js` (`requestBolt11FromLnurlPayService`, lines 121–156) — this path simply bypassed them.

**Payjoin:** `decodeBitcoinUri()` accepted any `pj=` value verbatim, including cleartext `http://` endpoints that would receive the PSBT in the clear (BIP78 requires HTTPS, HTTP only for .onion).

## Fix

- New `src/api/lnurlPayValidation.ts` mirrors the hardened checks: https-only callbacks (http only for .onion), min/max sendable enforcement, invoice-amount equality, metadata `description_hash` verification, and correct query joining for callbacks that already carry parameters (the old code blindly appended `?amount=`).
- `decodeBitcoinUri()` drops non-https `pj=` endpoints and falls back to a normal send.

## Tests

- 11 new unit cases, including a positive-control fixture (a real 10-sat invoice whose `description_hash` matches its metadata) and payjoin http / non-URL / https cases.
- Existing deeplink suite green: **39/39**.
- `tsc`: no new errors in touched files (two pre-existing errors elsewhere, unrelated).