### PR TITLE
fix(security): purge Ark seed cache on background; throttle password attempts on Android

### DIFF
--- a/App.js
+++ b/App.js
@@ -32,6 +32,7 @@ import Privacy from './blue_modules/Privacy';
 import MenuElements from './components/MenuElements';
 import PaymentNotification from './src/components/PaymentNotification';
 import { updateExchangeRate } from './blue_modules/currency';
+import { purgeCachedArkMnemonic } from './src/services/ark/walletHandle';
 // Side-effect import: configures the Google Drive OAuth client at app
 // startup using the GOOGLE_WEB_CLIENT_ID from .env (via react-native-
 // config). No-op on iOS and on Android if the env var is unset; we
@@ -223,6 +224,11 @@ const App = () => {
 
   const handleAppStateChange = async nextAppState => {
     if (wallets.length === 0) return;
+    if (nextAppState === 'background' || nextAppState === 'inactive') {
+      // Never leave the Ark seed sitting in JS memory while the app is
+      // suspended; it is re-read from Keychain on next use.
+      purgeCachedArkMnemonic();
+    }
     if ((appState.current.match(/background/) && nextAppState === 'active') || nextAppState === undefined) {
       setTimeout(() => A(A.ENUM.APP_UNSUSPENDED), 2000);
       updateExchangeRate();

--- a/BlueApp.js
+++ b/BlueApp.js
@@ -990,6 +990,14 @@ const startAndDecrypt = async retry => {
     // we had password and yet could not load/decrypt
     unlockAttempt++;
     if (unlockAttempt < 10 || Platform.OS !== 'ios') {
+      // Online brute-force throttle on ALL platforms: exponential backoff
+      // from the 5th failed attempt, capped at 30s. Android previously
+      // recursed immediately forever; iOS additionally offers the keychain
+      // wipe at 10 attempts (else branch below).
+      if (unlockAttempt >= 5) {
+        const backoffMs = Math.min(30000, 2 ** (unlockAttempt - 5) * 1000);
+        await new Promise(resolve => setTimeout(resolve, backoffMs));
+      }
       return startAndDecrypt(true);
     } else {
       unlockAttempt = 0;

--- a/src/services/ark/walletHandle.ts
+++ b/src/services/ark/walletHandle.ts
@@ -34,8 +34,19 @@ let sessionEsploraUrl: string = ESPLORA_URL;
 // hitting Keychain — which on some iOS configurations triggers a biometric
 // prompt. Only ever holds one value (there is exactly one Ark wallet per
 // session). Cleared when the handle is torn down so a dangling mnemonic
-// string can't outlive its wallet.
+// string can't outlive its wallet, and purged when the app goes to
+// background so a seed never sits in JS memory while suspended.
 let cachedMnemonic: string | null = null;
+
+/**
+ * Drop the in-memory mnemonic cache WITHOUT tearing down the wallet handle.
+ * Called when the app backgrounds: the seed is re-read from Keychain on next
+ * use (at most one biometric prompt), instead of living in JS memory for the
+ * whole suspended lifetime of the process.
+ */
+export function purgeCachedArkMnemonic(): void {
+    cachedMnemonic = null;
+}
 
 // Last on-chain (BDK) balance observed by syncArkWallet, in sats. fetchArkBalance
 // reads THIS instead of making its own onchain.balance() call: that call races


### PR DESCRIPTION
From the 2026-07 independent security review (full report available on request).

## Changes

1. **Ark mnemonic no longer lives in JS memory while suspended.** `walletHandle.ts` cached the Ark seed in a module-scope variable for the whole process lifetime (a deliberate workaround to avoid biometric re-prompts). New `purgeCachedArkMnemonic()` drops the cache without tearing down the wallet; `App.js` calls it when the app backgrounds/inactivates. The seed is re-read from Keychain on next use (at most one biometric prompt).

2. **Android password-attempt throttle.** `startAndDecrypt()`'s 10-attempt keychain-wipe escape was iOS-only; on Android the retry loop recursed immediately forever (CWE-307). All platforms now get exponential backoff from the 5th failed attempt (1s → capped 30s); the iOS wipe offer is unchanged.

## Deliberately out of scope

**Re-lock on background** (a default install has no app lock at all) is not in this PR: a correct implementation needs an overlay that *preserves navigation state* — the cold-start `UnlockWith` screen replaces the whole navigation stack on success, which would destroy an in-flight send flow on every resume. Recommended as a follow-up with a settings toggle; flagged in the review as a MEDIUM.

## Verification

- `App.js` / `BlueApp.js` parse (babel).
- `tsc`: zero new error classes vs `upstream/main`.
- No runtime test coverage added (both call sites need a device; the purge is a one-line cache null-out — review by inspection).