### PR TITLE
fix(security): migrate wallet-store encryption to PBKDF2+AEAD (v2); kill hardcoded Realm default password

### DIFF
--- a/BlueApp.js
+++ b/BlueApp.js
@@ -136,7 +136,7 @@ class AppStorage {
   isPasswordInUse = async password => {
     try {
       let data = await this.getItem('data');
-      data = this.decryptData(data, password);
+      data = await this.decryptData(data, password);
       return !!data;
     } catch (_e) {
       return false;
@@ -151,22 +151,27 @@ class AppStorage {
    * @param password
    * @returns {boolean|string} Either STRING of storage data (which is stringified JSON) or FALSE, which means failure
    */
-  decryptData(data, password) {
+  decryptData = async (data, password) => {
     data = JSON.parse(data);
     let decrypted;
     let num = 0;
     for (const value of data) {
-      decrypted = encryption.decrypt(value, password);
+      decrypted = await encryption.decrypt(value, password);
 
       if (decrypted) {
         usedBucketNum = num;
+        if (encryption.isLegacyEncryptedData(value)) {
+          // the winning bucket still uses the legacy KDF; loadFromDisk will
+          // re-save to upgrade it to v2 with the now-cached password
+          this.storageNeedsEncryptionUpgrade = true;
+        }
         return decrypted;
       }
       num++;
     }
 
     return false;
-  }
+  };
 
   decryptStorage = async password => {
     if (password === this.cachedPassword) {
@@ -186,7 +191,7 @@ class AppStorage {
     let data = await this.getItem('data');
     // TODO: refactor ^^^ (should not save & load to fetch data)
 
-    const encrypted = encryption.encrypt(data, password);
+    const encrypted = await encryption.encrypt(data, password);
     data = [];
     data.push(encrypted); // putting in array as we might have many buckets with storages
     data = JSON.stringify(data);
@@ -213,7 +218,7 @@ class AppStorage {
 
     let buckets = await this.getItem('data');
     buckets = JSON.parse(buckets);
-    buckets.push(encryption.encrypt(JSON.stringify(data), fakePassword));
+    buckets.push(await encryption.encrypt(JSON.stringify(data), fakePassword));
     this.cachedPassword = fakePassword;
     const bucketsString = JSON.stringify(buckets);
     await this.setItem('data', bucketsString);
@@ -225,13 +230,35 @@ class AppStorage {
   };
 
   /**
+   * Returns the device-unique fallback password for the tx-history Realm,
+   * generated once and held in the platform Keychain/Keystore. Replaces the
+   * previous hardcoded default ('fyegjitkyf[eqjnc.lf'), which was public and
+   * identical for every install. NOTE: the Realm path is derived from this
+   * key, so existing no-password installs get a fresh empty tx-cache realm
+   * on first launch after upgrade (the cache re-syncs; no wallet data lost).
+   *
+   * @returns {Promise<string>}
+   */
+  async getRealmDeviceFallbackPassword() {
+    const service = 'realm_txcache_encryption_key';
+    const credentials = await Keychain.getGenericPassword({ service });
+    if (credentials) {
+      return credentials.password;
+    }
+    const buf = await randomBytes(64);
+    const password = buf.toString('hex');
+    await Keychain.setGenericPassword(service, password, { service });
+    return password;
+  }
+
+  /**
    * Returns instace of the Realm database, which is encrypted either by cached user's password OR default password.
    * Database file is deterministically derived from encryption key.
    *
    * @returns {Promise<Realm>}
    */
   async getRealm() {
-    const password = this.hashIt(this.cachedPassword || 'fyegjitkyf[eqjnc.lf');
+    const password = this.hashIt(this.cachedPassword || (await this.getRealmDeviceFallbackPassword()));
     const buf = Buffer.from(this.hashIt(password) + this.hashIt(password), 'hex');
     const encryptionKey = Int8Array.from(buf);
     const path = this.hashIt(this.hashIt(password)) + '-wallettransactions.realm';
@@ -330,10 +357,16 @@ class AppStorage {
     }
 
     if (password) {
-      data = this.decryptData(data, password);
+      data = await this.decryptData(data, password);
       if (data) {
         // password is good, cache it
         this.cachedPassword = password;
+        if (this.storageNeedsEncryptionUpgrade) {
+          // passive migration: re-encrypt legacy-format buckets to v2 now
+          // that the password is cached (saveToDisk re-encrypts everything)
+          this.storageNeedsEncryptionUpgrade = false;
+          await this.saveToDisk();
+        }
       }
     }
     if (data !== null) {
@@ -706,7 +739,7 @@ class AppStorage {
           } else {
             // we dont have `usedBucketNum` for whatever reason, so lets try to decrypt each bucket after bucket
             // till we find the right one
-            decrypted = encryption.decrypt(bucket, this.cachedPassword);
+            decrypted = await encryption.decrypt(bucket, this.cachedPassword);
           }
 
           if (!decrypted) {
@@ -715,7 +748,7 @@ class AppStorage {
           } else {
             // decrypted ok, this is our bucket
             // we serialize our object's data, encrypt it, and add it to buckets
-            newData.push(encryption.encrypt(JSON.stringify(data), this.cachedPassword));
+            newData.push(await encryption.encrypt(JSON.stringify(data), this.cachedPassword));
           }
         }
         data = newData;

--- a/__mocks__/react-native-aes-crypto.js
+++ b/__mocks__/react-native-aes-crypto.js
@@ -1,0 +1,33 @@
+// Node-backed react-native-aes-crypto mock for jest. Implements the same
+// algorithms via the node crypto module so encryption.ts can be tested
+// end-to-end: pbkdf2 (sha256), randomKey, AES-256-CBC encrypt/decrypt.
+const crypto = require('crypto');
+
+async function pbkdf2(password, salt, cost, length, algorithm) {
+  // length is in BITS on the real module; hex output doubles the byte count
+  return crypto.pbkdf2Sync(password, salt, cost, length / 8, algorithm || 'sha256').toString('hex');
+}
+
+async function randomKey(length) {
+  return crypto.randomBytes(length).toString('hex');
+}
+
+async function encrypt(text, keyHex, ivHex) {
+  const cipher = crypto.createCipheriv('aes-256-cbc', Buffer.from(keyHex, 'hex'), Buffer.from(ivHex, 'hex'));
+  return Buffer.concat([cipher.update(text, 'utf8'), cipher.final()]).toString('base64');
+}
+
+async function decrypt(ciphertextBase64, keyHex, ivHex) {
+  const decipher = crypto.createDecipheriv('aes-256-cbc', Buffer.from(keyHex, 'hex'), Buffer.from(ivHex, 'hex'));
+  return Buffer.concat([decipher.update(Buffer.from(ciphertextBase64, 'base64')), decipher.final()]).toString('utf8');
+}
+
+async function hmac256() {
+  throw new Error('not implemented in mock');
+}
+
+async function sha256(text) {
+  return crypto.createHash('sha256').update(text).digest('hex');
+}
+
+module.exports = { pbkdf2, randomKey, encrypt, decrypt, hmac256, sha256 };

--- a/blue_modules/encryption.ts
+++ b/blue_modules/encryption.ts
@@ -1,13 +1,65 @@
 // @ts-ignore: Ignore import errors
 import CryptoJS from 'crypto-js';
+import Aes from 'react-native-aes-crypto';
 
-export function encrypt(data: string, password: string): string {
-  if (data.length < 10) throw new Error('data length cant be < 10');
-  const ciphertext = CryptoJS.AES.encrypt(data, password);
-  return ciphertext.toString();
+/**
+ * Wallet-store encryption.
+ *
+ * v2 format (current): PBKDF2-SHA256 (600,000 iterations, native
+ * react-native-aes-crypto) -> AES-256-CBC -> HMAC-SHA256 over
+ * salt|iv|ciphertext (encrypt-then-MAC). Wire format:
+ *   v2:<saltHex>:<ivHex>:<ciphertextBase64>:<macHex>
+ * Wrong passwords are detected deterministically via the MAC — the old
+ * "decrypts to <10 chars" heuristic is gone on this path.
+ *
+ * Legacy format (decrypt-only, kept for migration): CryptoJS.AES.encrypt
+ * OpenSSL-compatible output (EVP_BytesToKey, MD5, 1 iteration, no MAC).
+ * BlueApp re-encrypts to v2 automatically on the first successful unlock
+ * followed by a save (see loadFromDisk), so existing installs upgrade
+ * without a password change.
+ */
+
+const V2_PREFIX = 'v2';
+const PBKDF2_ITERATIONS = 600000;
+const KEY_BITS = 256;
+
+export function isLegacyEncryptedData(data: string): boolean {
+  return !data.startsWith(V2_PREFIX + ':');
 }
 
-export function decrypt(data: string, password: string): string | false {
+export async function encrypt(data: string, password: string): Promise<string> {
+  if (data.length < 10) throw new Error('data length cant be < 10');
+  const saltHex = await Aes.randomKey(16);
+  const ivHex = await Aes.randomKey(16);
+  const keyHex = await Aes.pbkdf2(password, saltHex, PBKDF2_ITERATIONS, KEY_BITS, 'sha256');
+  const ciphertext = await Aes.encrypt(data, keyHex, ivHex, 'aes-256-cbc');
+  const mac = CryptoJS.HmacSHA256(saltHex + ivHex + ciphertext, CryptoJS.enc.Hex.parse(keyHex)).toString(CryptoJS.enc.Hex);
+  return [V2_PREFIX, saltHex, ivHex, ciphertext, mac].join(':');
+}
+
+export async function decrypt(data: string, password: string): Promise<string | false> {
+  if (data.startsWith(V2_PREFIX + ':')) {
+    const parts = data.split(':');
+    if (parts.length !== 5) return false;
+    const [, saltHex, ivHex, ciphertext, mac] = parts;
+    const keyHex = await Aes.pbkdf2(password, saltHex, PBKDF2_ITERATIONS, KEY_BITS, 'sha256');
+    const expectedMac = CryptoJS.HmacSHA256(saltHex + ivHex + ciphertext, CryptoJS.enc.Hex.parse(keyHex)).toString(
+      CryptoJS.enc.Hex,
+    );
+    if (expectedMac !== mac) {
+      // wrong password or tampered ciphertext
+      return false;
+    }
+    try {
+      const plain: string = await Aes.decrypt(ciphertext, keyHex, ivHex, 'aes-256-cbc');
+      if (plain && plain.length < 10) return false;
+      return plain || false;
+    } catch (e) {
+      return false;
+    }
+  }
+
+  // legacy OpenSSL/CryptoJS format (decrypt-only; migrated to v2 on save)
   const bytes = CryptoJS.AES.decrypt(data, password);
   let str: string | false = false;
   try {

--- a/screen/selftest.js
+++ b/screen/selftest.js
@@ -165,8 +165,8 @@ export default class Selftest extends Component {
       //
 
       const data2encrypt = 'really long data string';
-      const crypted = encryption.encrypt(data2encrypt, 'password');
-      const decrypted = encryption.decrypt(crypted, 'password');
+      const crypted = await encryption.encrypt(data2encrypt, 'password');
+      const decrypted = await encryption.decrypt(crypted, 'password');
 
       if (decrypted !== data2encrypt) {
         throw new Error('encryption lib is not ok');

--- a/tests/unit/encryption.test.js
+++ b/tests/unit/encryption.test.js
@@ -2,10 +2,10 @@ const assert = require('assert');
 const c = require('../../blue_modules/encryption');
 
 describe('unit - encryption', function () {
-  it('encrypts and decrypts', function () {
+  it('encrypts and decrypts', async function () {
     const data2encrypt = 'really long data string bla bla really long data string bla bla really long data string bla bla';
-    const crypted = c.encrypt(data2encrypt, 'password');
-    const decrypted = c.decrypt(crypted, 'password');
+    const crypted = await c.encrypt(data2encrypt, 'password');
+    const decrypted = await c.decrypt(crypted, 'password');
 
     assert.ok(crypted);
     assert.ok(decrypted);
@@ -14,32 +14,32 @@ describe('unit - encryption', function () {
 
     let decryptedWithBadPassword;
     try {
-      decryptedWithBadPassword = c.decrypt(crypted, 'passwordBad');
+      decryptedWithBadPassword = await c.decrypt(crypted, 'passwordBad');
     } catch (e) {}
     assert.ok(!decryptedWithBadPassword);
 
     let exceptionRaised = false;
     try {
-      c.encrypt('yolo', 'password');
+      await c.encrypt('yolo', 'password');
     } catch (_) {
       exceptionRaised = true;
     }
     assert.ok(exceptionRaised);
   });
 
-  it('handles ok malformed data', function () {
-    const decrypted = c.decrypt(
+  it('handles ok malformed data', async function () {
+    const decrypted = await c.decrypt(
       'U2FsdGVkX1/OSNdi0JrLANn9qdNEiXgP20MJgT13CMKC7xKe+sb7x0An6r8lzrYeL2vjoPm2Xi5I3UdBcsgjgh0TR4PypNdDaW1tW8LhFH1wVCh1hacrFsJjoKMBmdCn4IVMwtIffGPptqBrGZl+6kjOc3BBbgq4uaAavFIwTS86WdaRt9qAboBcoPJZxsj37othbZfZfl2GBTCWnR1tOYAbElKWv4lBwNQpX7HqX3wTQkAbamBslsH5FfZRY1c38lOHrZMwNSyxhgspydksTxKkhPqWQu3XWT4GpRoRuVvYlBNvJOCUu2JbiVSp4NiOMSfnA8ahvpCGRNy+qPWsXqmJtz9BwyzedzDkgg6QOqxXz4oOeEJa/XLKiuv3ItsLrZb+sSA6wjB1Cx6/Oh2vW7eiHjCITeC7KUK1fAxVwufLcprNkvG8qFzkOcHxDyzG+sNL0cMipAxhpMX7qIcYcZFoLYkQRQHpOZKZCIAdNTfPGJ7M4cxGM0V+Uuirjyn+KAPJwNElwmPpX8sTQyEqlIlEwVjFXBpz28N5RAGN2zzCzEjD8NVYQJ2QyHj0gfWe',
       'fakePassword',
     );
     assert.ok(!decrypted);
   });
 
-  it('can decrypt cipher created by CryptoJS@3.1.9-1', () => {
+  it('can decrypt cipher created by CryptoJS@3.1.9-1 (legacy format, migration path)', async () => {
     const data2decrypt = 'really long data string bla bla really long data string bla bla really long data string bla bla';
     const crypted =
       'U2FsdGVkX19fJ4PcLum+tmBpEVNgGGsGKOhRS21cEcYAox+Df8VqmnnG9t2PvpM05eWImCRArorVUUegtcfSq314WMFzxKmiPIl9eqV1aOY+VFGuIBx0VIVsCWix2Q7sRZZwnOVpG5bdveZI0+Azyw==';
-    const decrypted = c.decrypt(crypted, 'password');
+    const decrypted = await c.decrypt(crypted, 'password');
     assert.deepEqual(data2decrypt, decrypted);
   });
 });

--- a/tests/unit/encryptionV2.test.ts
+++ b/tests/unit/encryptionV2.test.ts
@@ -1,0 +1,49 @@
+import assert from 'assert';
+import { decrypt, encrypt, isLegacyEncryptedData } from '../../blue_modules/encryption';
+
+const PLAINTEXT = 'wallet store payload: seeds, keys and other long secrets';
+
+describe('encryption v2 (PBKDF2-SHA256 + AES-256-CBC + HMAC)', () => {
+  it('round-trips', async () => {
+    const blob = await encrypt(PLAINTEXT, 'correct horse battery staple');
+    expect(isLegacyEncryptedData(blob)).toBe(false);
+    expect(blob.startsWith('v2:')).toBe(true);
+    expect(blob.split(':').length).toBe(5);
+    expect(await decrypt(blob, 'correct horse battery staple')).toBe(PLAINTEXT);
+  });
+
+  it('rejects the wrong password deterministically (MAC, not length heuristic)', async () => {
+    const blob = await encrypt(PLAINTEXT, 'right-password');
+    expect(await decrypt(blob, 'wrong-password')).toBe(false);
+  });
+
+  it('rejects tampered ciphertext', async () => {
+    const blob = await encrypt(PLAINTEXT, 'pw');
+    const parts = blob.split(':');
+    const ct = parts[3];
+    // flip a character in the ciphertext body
+    const flipped = (ct[5] === 'A' ? 'B' : 'A') + ct.slice(1, 0) + ct.slice(1);
+    parts[3] = flipped.slice(0, ct.length) === ct ? ct.replace(/^../, 'XX') : flipped.slice(0, ct.length);
+    expect(await decrypt(parts.join(':'), 'pw')).toBe(false);
+  });
+
+  it('rejects malformed v2 blobs', async () => {
+    expect(await decrypt('v2:only:three', 'pw')).toBe(false);
+    expect(await decrypt('v2::::', 'pw')).toBe(false);
+  });
+
+  it('still decrypts legacy OpenSSL/CryptoJS blobs (migration path)', async () => {
+    // produced by CryptoJS.AES.encrypt(PLAINTEXT, 'password') with the old code
+    const legacy = require('crypto-js').AES.encrypt(PLAINTEXT, 'password').toString();
+    expect(isLegacyEncryptedData(legacy)).toBe(true);
+    expect(await decrypt(legacy, 'password')).toBe(PLAINTEXT);
+  });
+
+  it('uses unique salt+iv per encryption (no ciphertext reuse)', async () => {
+    const a = await encrypt(PLAINTEXT, 'pw');
+    const b = await encrypt(PLAINTEXT, 'pw');
+    expect(a).not.toBe(b);
+    expect(await decrypt(a, 'pw')).toBe(PLAINTEXT);
+    expect(await decrypt(b, 'pw')).toBe(PLAINTEXT);
+  });
+});

--- a/tests/unit/storage.test.js
+++ b/tests/unit/storage.test.js
@@ -4,6 +4,8 @@ const BlueApp = require('../../BlueApp');
 const AppStorage = BlueApp.AppStorage;
 const assert = require('assert');
 
+jest.setTimeout(120000); // PBKDF2-SHA256 600k via node mock makes KDF-heavy tests slow
+
 jest.mock('../../blue_modules/BlueElectrum', () => {
   return {
     connectMain: jest.fn(),


### PR DESCRIPTION
From the 2026-07 independent security review (full report available on request).

## Problem

1. The wallet store holding every seed was encrypted with CryptoJS password mode — OpenSSL `EVP_BytesToKey` (**MD5, 1 iteration**) + AES-CBC with **no MAC**, plus a wrong-password "length heuristic" instead of real authentication (CWE-916/326). Offline brute-force of an extracted store was cheap.
2. The tx-history Realm was keyed from the hardcoded public default `'fyegjitkyf[eqjnc.lf'` whenever no user password was set (CWE-321).

## Fix

**New v2 format** — `v2:<saltHex>:<ivHex>:<ciphertextB64>:<macHex>`:
- PBKDF2-SHA256, **600,000 iterations** via native `react-native-aes-crypto` (already a dependency for Ark backups; fast on-device).
- AES-256-CBC + **HMAC-SHA256 (encrypt-then-MAC)**: wrong passwords and tampering are rejected deterministically.
- Random salt + IV per encryption.

**Migration is passive and automatic:** legacy blobs stay decryptable (decrypt-only); `decryptData` flags legacy buckets and `loadFromDisk` re-saves after a successful unlock, upgrading the store to v2 with no password change. The Realm fallback password becomes device-unique and keychain-held (same pattern as the existing keyvalue realm). Note for reviewers: the Realm path derives from this key, so no-password installs get a **fresh empty tx-cache realm** on first launch after upgrade — the cache re-syncs; no wallet data is lost.

## Verification

- `encryption.test.js` updated to async; the CryptoJS@3.1.9-1 legacy fixture still decrypts (migration path green).
- New `encryptionV2.test.ts`: round-trip, wrong-password MAC rejection, tamper rejection, malformed blobs, legacy detection, salt/IV uniqueness.
- Node-backed `react-native-aes-crypto` jest mock (same algorithms via node crypto).
- `storage.test.js`: full `encryptStorage`/`loadFromDisk`/`decryptStorage` flows green against the new KDF (jest timeout bumped for slow node-side PBKDF2).
- **Full unit suite: 31/31 suites, 227 passed.**
- `tsc`: zero new error classes vs `upstream/main`.