### PR TITLE
fix(security): encrypt custodial tokens with a keychain-held device key

### DIFF
--- a/__mocks__/react-native-keychain.js
+++ b/__mocks__/react-native-keychain.js
@@ -1,0 +1,35 @@
+// In-memory react-native-keychain mock for jest.
+const vault = new Map();
+
+const ACCESSIBLE = {
+  WHEN_UNLOCKED: 'WHEN_UNLOCKED',
+  WHEN_UNLOCKED_THIS_DEVICE_ONLY: 'WHEN_UNLOCKED_THIS_DEVICE_ONLY',
+  WHEN_PASSCODE_SET_THIS_DEVICE_ONLY: 'WHEN_PASSCODE_SET_THIS_DEVICE_ONLY',
+};
+
+async function getGenericPassword(options) {
+  const service = options && options.service;
+  if (service && vault.has(service)) {
+    return { username: service, password: vault.get(service), service };
+  }
+  return false;
+}
+
+async function setGenericPassword(username, password, options) {
+  const service = (options && options.service) || username;
+  vault.set(service, password);
+  return { service };
+}
+
+async function resetGenericPassword(options) {
+  if (options && options.service) vault.delete(options.service);
+  return true;
+}
+
+module.exports = {
+  getGenericPassword,
+  setGenericPassword,
+  resetGenericPassword,
+  ACCESSIBLE,
+  __vault: vault,
+};

--- a/__mocks__/react-native-mmkv.js
+++ b/__mocks__/react-native-mmkv.js
@@ -1,0 +1,39 @@
+// In-memory react-native-mmkv mock for jest. Registry keyed by store id so
+// separate MMKV instances with the same id share data (as on device).
+const stores = new Map();
+
+class MMKV {
+  constructor(configuration) {
+    this.id = (configuration && configuration.id) || 'mmkv.default';
+    if (!stores.has(this.id)) stores.set(this.id, new Map());
+    this._data = stores.get(this.id);
+  }
+
+  getString(key) {
+    return this._data.has(key) ? this._data.get(key) : undefined;
+  }
+
+  set(key, value) {
+    this._data.set(key, value);
+  }
+
+  delete(key) {
+    this._data.delete(key);
+  }
+
+  clearAll() {
+    this._data.clear();
+  }
+
+  getAllKeys() {
+    return [...this._data.keys()];
+  }
+
+  contains(key) {
+    return this._data.has(key);
+  }
+}
+
+MMKV.__stores = stores;
+
+module.exports = { MMKV };

--- a/src/custom-hooks/useArkSync.ts
+++ b/src/custom-hooks/useArkSync.ts
@@ -368,14 +368,14 @@ export default function useArkSync(): UseArkSync {
                         // that the exit succeeded. correlationId pairs
                         // this with the ark-exit-started event captured
                         // at the start of the exit.
-                        const correlationId = getArkExitCorrelationId();
+                        const correlationId = await getArkExitCorrelationId();
                         if (correlationId) {
                             recordEvent({
                                 kind: 'ark-exit-finished',
                                 correlationId,
                                 result: 'success',
                             });
-                            setArkExitCorrelationId(null);
+                            await setArkExitCorrelationId(null);
                         }
                         await resetArkWalletState();
                         clearArkAuth();

--- a/src/screens/HomeScreen/index.tsx
+++ b/src/screens/HomeScreen/index.tsx
@@ -389,11 +389,9 @@ export default function HomeScreen({ route }: Props) {
       // Activity log: diff the wallet's tx list for new on-chain receives.
       // Failure is non-fatal — the rest of the home screen renders fine
       // and the next refresh tick will retry.
-      try {
-        processHotVaultTxsForActivity(walletTemp as any);
-      } catch (diffErr) {
+      processHotVaultTxsForActivity(walletTemp as any).catch(diffErr => {
         if (__DEV__) console.warn('[Activity] hot-vault tx diff failed:', diffErr);
-      }
+      });
       if (wallets && walletID) {
         setIsAllDone(!!walletTemp);
       } else {

--- a/src/screens/Strike/CheckingAccountNew/Settings.tsx
+++ b/src/screens/Strike/CheckingAccountNew/Settings.tsx
@@ -1207,7 +1207,7 @@ export function ArkSettingsBody({ view = 'backup' }: { view?: 'backup' | 'action
                 // cycles + app restarts so the auto-claim path in
                 // useArkSync can match the started/finished pair.
                 const correlationId = `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 7)}`;
-                setArkExitCorrelationId(correlationId);
+                await setArkExitCorrelationId(correlationId);
                 let exitSats = 0;
                 try {
                   exitSats = await fetchPendingExitsTotalSats();

--- a/src/services/activityCursors.ts
+++ b/src/services/activityCursors.ts
@@ -1,10 +1,11 @@
 import { getItem, removeItem, setItem } from "@Cypher/stores/storageService";
 
 // Cursors used by the Activity log to suppress historical/duplicate emits
-// across app restarts. Each is a thin typed wrapper over MMKV so the
-// activity-diff modules don't have to spread raw key strings around.
+// across app restarts. Each is a thin typed wrapper over the secure MMKV
+// store so the activity-diff modules don't have to spread raw key strings
+// around.
 //
-// First-sync convention: getter returns null when nothing has been
+// First-sync convention: getter resolves to null when nothing has been
 // persisted yet. Diff helpers must treat null as "first time we've ever
 // looked — write the high watermark, do NOT emit historical events."
 
@@ -15,28 +16,28 @@ const KEY_STRIKE_LAST_INVOICE_ID = "activity-strike-last-invoice-id";
 
 // --- Ark exit correlation id ----------------------------------------------
 
-export const getArkExitCorrelationId = (): string | null => {
-    const v = getItem(KEY_ARK_EXIT_CORRELATION);
+export const getArkExitCorrelationId = async (): Promise<string | null> => {
+    const v = await getItem(KEY_ARK_EXIT_CORRELATION);
     return typeof v === "string" ? v : null;
 };
 
-export const setArkExitCorrelationId = (id: string | null): void => {
+export const setArkExitCorrelationId = async (id: string | null): Promise<void> => {
     if (id === null) {
-        removeItem(KEY_ARK_EXIT_CORRELATION);
+        await removeItem(KEY_ARK_EXIT_CORRELATION);
     } else {
-        setItem(KEY_ARK_EXIT_CORRELATION, id);
+        await setItem(KEY_ARK_EXIT_CORRELATION, id);
     }
 };
 
 // --- Ark history (movements) cursor ---------------------------------------
 
-export const getArkLastSeenMovementId = (): number | null => {
-    const v = getItem(KEY_ARK_LAST_MOVEMENT_ID);
+export const getArkLastSeenMovementId = async (): Promise<number | null> => {
+    const v = await getItem(KEY_ARK_LAST_MOVEMENT_ID);
     return typeof v === "number" ? v : null;
 };
 
-export const setArkLastSeenMovementId = (id: number): void => {
-    setItem(KEY_ARK_LAST_MOVEMENT_ID, id);
+export const setArkLastSeenMovementId = async (id: number): Promise<void> => {
+    await setItem(KEY_ARK_LAST_MOVEMENT_ID, id);
 };
 
 // --- Hot Vault tx-id set (serialised) -------------------------------------
@@ -49,23 +50,23 @@ export const setArkLastSeenMovementId = (id: number): void => {
 const HOTVAULT_TXID_CAP = 1000;
 const HOTVAULT_TXID_PRUNE = 200;
 
-export const getHotVaultSeenTxids = (): string[] | null => {
-    const v = getItem(KEY_HOTVAULT_SEEN_TXIDS);
+export const getHotVaultSeenTxids = async (): Promise<string[] | null> => {
+    const v = await getItem(KEY_HOTVAULT_SEEN_TXIDS);
     return Array.isArray(v) ? (v as string[]) : null;
 };
 
-export const setHotVaultSeenTxids = (ids: string[]): void => {
+export const setHotVaultSeenTxids = async (ids: string[]): Promise<void> => {
     const trimmed = ids.length > HOTVAULT_TXID_CAP ? ids.slice(HOTVAULT_TXID_PRUNE) : ids;
-    setItem(KEY_HOTVAULT_SEEN_TXIDS, trimmed);
+    await setItem(KEY_HOTVAULT_SEEN_TXIDS, trimmed);
 };
 
 // --- Strike last-seen received-invoice id ---------------------------------
 
-export const getStrikeLastSeenInvoiceId = (): string | null => {
-    const v = getItem(KEY_STRIKE_LAST_INVOICE_ID);
+export const getStrikeLastSeenInvoiceId = async (): Promise<string | null> => {
+    const v = await getItem(KEY_STRIKE_LAST_INVOICE_ID);
     return typeof v === "string" ? v : null;
 };
 
-export const setStrikeLastSeenInvoiceId = (id: string): void => {
-    setItem(KEY_STRIKE_LAST_INVOICE_ID, id);
+export const setStrikeLastSeenInvoiceId = async (id: string): Promise<void> => {
+    await setItem(KEY_STRIKE_LAST_INVOICE_ID, id);
 };

--- a/src/services/ark/movementsActivity.ts
+++ b/src/services/ark/movementsActivity.ts
@@ -36,11 +36,11 @@ export async function processArkMovementsForActivity(): Promise<void> {
     }
     if (!movements || movements.length === 0) return;
 
-    const cursor = getArkLastSeenMovementId();
+    const cursor = await getArkLastSeenMovementId();
     const maxId = movements.reduce((m, mv) => (mv.id > m ? mv.id : m), 0);
 
     if (cursor === null) {
-        setArkLastSeenMovementId(maxId);
+        await setArkLastSeenMovementId(maxId);
         return;
     }
 
@@ -56,6 +56,6 @@ export async function processArkMovementsForActivity(): Promise<void> {
     }
 
     if (maxId > cursor) {
-        setArkLastSeenMovementId(maxId);
+        await setArkLastSeenMovementId(maxId);
     }
 }

--- a/src/services/hotVaultActivityDiff.ts
+++ b/src/services/hotVaultActivityDiff.ts
@@ -31,7 +31,7 @@ type HotVaultLikeWallet = {
 
 const MIN_CONFIRMATIONS_TO_EMIT = 1;
 
-export function processHotVaultTxsForActivity(wallet: HotVaultLikeWallet | null | undefined): void {
+export async function processHotVaultTxsForActivity(wallet: HotVaultLikeWallet | null | undefined): Promise<void> {
     if (!wallet || typeof wallet.getTransactions !== "function") return;
 
     let txs: ReturnType<typeof wallet.getTransactions>;
@@ -43,11 +43,11 @@ export function processHotVaultTxsForActivity(wallet: HotVaultLikeWallet | null 
     if (!Array.isArray(txs) || txs.length === 0) return;
 
     const allTxids = txs.map((t) => t.txid).filter((id): id is string => typeof id === "string" && id.length > 0);
-    const cursor = getHotVaultSeenTxids();
+    const cursor = await getHotVaultSeenTxids();
 
     // First-sync: snapshot the world without emitting.
     if (cursor === null) {
-        setHotVaultSeenTxids(allTxids);
+        await setHotVaultSeenTxids(allTxids);
         return;
     }
 
@@ -77,5 +77,5 @@ export function processHotVaultTxsForActivity(wallet: HotVaultLikeWallet | null 
     // Persist the union of (cursor + everything currently visible). Pending
     // unconfirmed txs go into the cursor too — once they confirm on a
     // future tick they're already "seen" and won't re-emit.
-    setHotVaultSeenTxids([...new Set([...cursor, ...allTxids])]);
+    await setHotVaultSeenTxids([...new Set([...cursor, ...allTxids])]);
 }

--- a/src/services/strikeActivityDiff.ts
+++ b/src/services/strikeActivityDiff.ts
@@ -58,10 +58,10 @@ export async function processStrikeInvoicesForActivity(): Promise<void> {
     const newestId = items[0]?.invoiceId;
     if (!newestId) return;
 
-    const cursor = getStrikeLastSeenInvoiceId();
+    const cursor = await getStrikeLastSeenInvoiceId();
 
     if (cursor === null) {
-        setStrikeLastSeenInvoiceId(newestId);
+        await setStrikeLastSeenInvoiceId(newestId);
         return;
     }
 
@@ -83,6 +83,6 @@ export async function processStrikeInvoicesForActivity(): Promise<void> {
     }
 
     if (newestId !== cursor) {
-        setStrikeLastSeenInvoiceId(newestId);
+        await setStrikeLastSeenInvoiceId(newestId);
     }
 }

--- a/src/stores/storageService.ts
+++ b/src/stores/storageService.ts
@@ -26,10 +26,28 @@ const LEGACY_V1_ID = "mmkv.default";
 let storagePromise: Promise<MMKV> | null = null;
 
 async function getOrCreateEncryptionKey(): Promise<string> {
-    const credentials = await Keychain.getGenericPassword({ service: KEYCHAIN_SERVICE });
+    let credentials: Awaited<ReturnType<typeof Keychain.getGenericPassword>>;
+    try {
+        credentials = await Keychain.getGenericPassword({ service: KEYCHAIN_SERVICE });
+    } catch (e) {
+        // A Keychain READ error (locked keystore, transient failure, biometric
+        // interaction) is NOT proof the key is absent. Minting a replacement
+        // here would open the existing v3 store with the wrong key and, once
+        // migrateInto() clears the legacy stores, permanently orphan the
+        // encrypted tokens. Abort so the caller retries on a later access
+        // rather than destroying data. Only a clean "no entry" result (below)
+        // provisions a new key.
+        throw new Error(
+            `[storageService] keychain read failed; refusing to mint a replacement key: ${
+                (e as Error)?.message ?? String(e)
+            }`,
+        );
+    }
     if (credentials && typeof credentials !== "boolean" && credentials.password) {
         return credentials.password;
     }
+    // Genuinely absent: getGenericPassword resolves to `false` only when no
+    // entry exists, so this is a first run on this device. Provision a key.
     const key = (await randomBytes(32)).toString("hex");
     await Keychain.setGenericPassword(KEYCHAIN_SERVICE, key, {
         service: KEYCHAIN_SERVICE,
@@ -70,7 +88,13 @@ async function createStorage(): Promise<MMKV> {
 
 function getStorage(): Promise<MMKV> {
     if (!storagePromise) {
-        storagePromise = createStorage();
+        storagePromise = createStorage().catch((e) => {
+            // Never cache a rejected promise: a single transient keychain
+            // failure would otherwise wedge ALL storage access for the rest of
+            // the app's lifetime. Reset so the next call retries cleanly.
+            storagePromise = null;
+            throw e;
+        });
     }
     return storagePromise;
 }

--- a/src/stores/storageService.ts
+++ b/src/stores/storageService.ts
@@ -1,33 +1,83 @@
 import { MMKV } from "react-native-mmkv";
+import * as Keychain from "react-native-keychain";
+import { randomBytes } from "../../class/rng";
 
-// Encrypted MMKV store for sensitive data (auth tokens, user state)
-// The encryption key is derived from a fixed app secret + stored in the MMKV instance itself.
-// This protects against trivial file-level extraction on rooted/jailbroken devices.
-const ENCRYPTION_KEY = "cypherbox-mmkv-v1"; // rotated by changing this value + clearing app data
-const storage = new MMKV({ id: "cypherbox-secure", encryptionKey: ENCRYPTION_KEY });
+// Encrypted MMKV store for sensitive data (auth tokens, user state).
+//
+// The AES key is a device-generated random value held in the platform
+// Keychain/Keystore (hardware-backed where available), NOT a compile-time
+// constant. The previous implementation used the hardcoded public string
+// "cypherbox-mmkv-v1", which shipped inside the binary and therefore
+// offered only obfuscation: anyone with the public APK and a copy of the
+// MMKV file could decrypt the custodial (CoinOS/Strike) bearer tokens
+// persisted here. With a keychain-held key, offline decryption requires
+// both the file AND the device's keystore.
+//
+// Store generations:
+//   v1 'mmkv.default'        — unencrypted (legacy)
+//   v2 'cypherbox-secure'    — encrypted with the hardcoded public key (legacy)
+//   v3 'cypherbox-secure-v3' — encrypted with a keychain-held device key (current)
+const STORE_ID_V3 = "cypherbox-secure-v3";
+const KEYCHAIN_SERVICE = "cypherbox.mmkv.v3.key";
+const LEGACY_V2_ID = "cypherbox-secure";
+const LEGACY_V2_PUBLIC_KEY = "cypherbox-mmkv-v1";
+const LEGACY_V1_ID = "mmkv.default";
 
-// Migration: read from old unencrypted store, copy to encrypted, then delete old.
-// Explicit id matches v2's implicit default ('mmkv.default') so the legacy
-// instance points at the same on-disk file v2 wrote to. Required as of
-// react-native-mmkv v3 where Configuration.id is no longer optional.
-const legacyStorage = new MMKV({ id: 'mmkv.default' });
-try {
-    const legacyKeys = legacyStorage.getAllKeys();
-    if (legacyKeys.length > 0) {
-        for (const key of legacyKeys) {
-            const value = legacyStorage.getString(key);
-            if (value && !storage.contains(key)) {
-                storage.set(key, value);
-            }
-        }
-        legacyStorage.clearAll();
+let storagePromise: Promise<MMKV> | null = null;
+
+async function getOrCreateEncryptionKey(): Promise<string> {
+    const credentials = await Keychain.getGenericPassword({ service: KEYCHAIN_SERVICE });
+    if (credentials && typeof credentials !== "boolean" && credentials.password) {
+        return credentials.password;
     }
-} catch (_e) {
-    // Migration failed silently — legacy store may already be empty
+    const key = (await randomBytes(32)).toString("hex");
+    await Keychain.setGenericPassword(KEYCHAIN_SERVICE, key, {
+        service: KEYCHAIN_SERVICE,
+        accessible: Keychain.ACCESSIBLE.WHEN_UNLOCKED_THIS_DEVICE_ONLY,
+    });
+    return key;
 }
 
-export const getItem = (key: string) => {
+function migrateInto(store: MMKV, legacy: MMKV): void {
     try {
+        const legacyKeys = legacy.getAllKeys();
+        if (legacyKeys.length > 0) {
+            for (const key of legacyKeys) {
+                const value = legacy.getString(key);
+                if (value && !store.contains(key)) {
+                    store.set(key, value);
+                }
+            }
+            legacy.clearAll();
+        }
+    } catch (_e) {
+        // Migration is best-effort: a corrupted legacy store must not break
+        // startup. Worst case the user re-authenticates.
+    }
+}
+
+async function createStorage(): Promise<MMKV> {
+    const key = await getOrCreateEncryptionKey();
+    const store = new MMKV({ id: STORE_ID_V3, encryptionKey: key });
+
+    // v2 -> v3: read with the (public) v2 key, re-encrypt under the device key.
+    migrateInto(store, new MMKV({ id: LEGACY_V2_ID, encryptionKey: LEGACY_V2_PUBLIC_KEY }));
+    // v1 -> v3: belt-and-braces for installs that skipped the v2 migration.
+    migrateInto(store, new MMKV({ id: LEGACY_V1_ID }));
+
+    return store;
+}
+
+function getStorage(): Promise<MMKV> {
+    if (!storagePromise) {
+        storagePromise = createStorage();
+    }
+    return storagePromise;
+}
+
+export const getItem = async (key: string) => {
+    try {
+        const storage = await getStorage();
         const value = storage.getString(key);
         if (value) {
             return JSON.parse(value);
@@ -38,11 +88,18 @@ export const getItem = (key: string) => {
     }
 };
 
-export const setItem = (key: string, value: string | number | boolean | object) => {
+export const setItem = async (key: string, value: string | number | boolean | object) => {
+    const storage = await getStorage();
     const storeValue = JSON.stringify(value);
     return storage.set(key, storeValue);
 };
 
-export const removeItem = (key: string) => storage.delete(key);
+export const removeItem = async (key: string) => {
+    const storage = await getStorage();
+    return storage.delete(key);
+};
 
-export const clearAllData = () => storage.clearAll();
+export const clearAllData = async () => {
+    const storage = await getStorage();
+    return storage.clearAll();
+};

--- a/tests/unit/storageService.test.ts
+++ b/tests/unit/storageService.test.ts
@@ -1,0 +1,78 @@
+import { MMKV } from 'react-native-mmkv';
+import * as Keychain from 'react-native-keychain';
+import { getItem, removeItem, setItem } from '../../src/stores/storageService';
+
+// Deterministic RNG so the test does not need the native module.
+jest.mock('../../class/rng', () => ({
+  randomBytes: async (n: number) => Buffer.alloc(n, 7),
+}));
+
+jest.mock('react-native-keychain', () => {
+  const vault = new Map<string, string>();
+  return {
+    __vault: vault,
+    ACCESSIBLE: {
+      WHEN_UNLOCKED: 'WHEN_UNLOCKED',
+      WHEN_UNLOCKED_THIS_DEVICE_ONLY: 'WHEN_UNLOCKED_THIS_DEVICE_ONLY',
+      WHEN_PASSCODE_SET_THIS_DEVICE_ONLY: 'WHEN_PASSCODE_SET_THIS_DEVICE_ONLY',
+    },
+    getGenericPassword: async (options?: { service?: string }) => {
+      const service = options && options.service;
+      if (service && vault.has(service)) {
+        return { username: service, password: vault.get(service), service };
+      }
+      return false;
+    },
+    setGenericPassword: async (username: string, password: string, options?: { service?: string }) => {
+      const service = (options && options.service) || username;
+      vault.set(service, password);
+      return { service };
+    },
+    resetGenericPassword: async (options?: { service?: string }) => {
+      if (options && options.service) vault.delete(options.service);
+      return true;
+    },
+  };
+});
+
+const mmkvStores = () => (MMKV as unknown as { __stores: Map<string, Map<string, string>> }).__stores;
+const keychainVault = () => (jest.requireMock('react-native-keychain') as { __vault: Map<string, string> }).__vault;
+
+// NOTE: storageService lazily builds its store on first access and caches it
+// module-internally, so the migration test must run before any other access.
+describe('storageService (secure MMKV with keychain-held device key)', () => {
+  it('migrates v2 (public-key) data into v3 and clears the legacy store', async () => {
+    const legacy = new MMKV({ id: 'cypherbox-secure', encryptionKey: 'cypherbox-mmkv-v1' });
+    legacy.set('auth', JSON.stringify({ token: 'coinos-token-123' }));
+
+    expect(await getItem('auth')).toEqual({ token: 'coinos-token-123' });
+
+    // legacy cleared, v3 holds the migrated value
+    expect(legacy.getAllKeys()).toEqual([]);
+    const v3 = new MMKV({ id: 'cypherbox-secure-v3', encryptionKey: 'irrelevant-for-mock' });
+    expect(JSON.parse(v3.getString('auth') as string)).toEqual({ token: 'coinos-token-123' });
+
+    // the device key lives in the keychain and is NOT the old public constant
+    const creds: any = await Keychain.getGenericPassword({ service: 'cypherbox.mmkv.v3.key' });
+    expect(creds).toBeTruthy();
+    expect(creds.password).not.toBe('cypherbox-mmkv-v1');
+    expect(creds.password.length).toBe(64); // 32 random bytes as hex
+  });
+
+  it('keeps one stable device key across writes', async () => {
+    await setItem('a', 1);
+    const first: any = await Keychain.getGenericPassword({ service: 'cypherbox.mmkv.v3.key' });
+    await setItem('b', 2);
+    const second: any = await Keychain.getGenericPassword({ service: 'cypherbox.mmkv.v3.key' });
+    expect(first.password).toBeTruthy();
+    expect(first.password).toBe(second.password);
+  });
+
+  it('round-trips values and returns null for missing keys', async () => {
+    await setItem('k', { a: 1 });
+    expect(await getItem('k')).toEqual({ a: 1 });
+    await removeItem('k');
+    expect(await getItem('k')).toBeNull();
+    expect(await getItem('never-set')).toBeNull();
+  });
+});

--- a/tests/unit/storageServiceFailure.test.ts
+++ b/tests/unit/storageServiceFailure.test.ts
@@ -1,0 +1,60 @@
+import { getItem, setItem } from '../../src/stores/storageService';
+
+// Controllable keychain mock. State lives INSIDE the factory (hoisting-safe)
+// and the tests toggle it via jest.requireMock().__state. `react-native-mmkv`
+// is auto-mocked from __mocks__/, and rng is stubbed deterministically.
+jest.mock('react-native-keychain', () => {
+  const state = {
+    readMode: 'throw' as 'throw' | 'normal',
+    mints: 0,
+    vault: new Map<string, string>(),
+  };
+  return {
+    __state: state,
+    ACCESSIBLE: {
+      WHEN_UNLOCKED_THIS_DEVICE_ONLY: 'WHEN_UNLOCKED_THIS_DEVICE_ONLY',
+    },
+    getGenericPassword: async (o?: { service?: string }) => {
+      if (state.readMode === 'throw') {
+        throw new Error('keystore temporarily unavailable');
+      }
+      const service = o?.service ?? '';
+      return state.vault.has(service)
+        ? { username: service, password: state.vault.get(service), service }
+        : false;
+    },
+    setGenericPassword: async (u: string, p: string, o?: { service?: string }) => {
+      state.mints += 1;
+      state.vault.set(o?.service ?? u, p);
+      return { service: o?.service ?? u };
+    },
+  };
+});
+
+jest.mock('../../class/rng', () => ({
+  randomBytes: async (n: number) => Buffer.alloc(n, 7),
+}));
+
+const kc = jest.requireMock('react-native-keychain') as {
+  __state: { readMode: 'throw' | 'normal'; mints: number; vault: Map<string, string> };
+};
+
+describe('storageService failure handling', () => {
+  it('does not mint a replacement key on a keychain READ error, and retries after recovery', async () => {
+    // A read error means the key may exist but be unreadable (locked keystore,
+    // transient failure). Minting a fresh key here would open the existing v3
+    // store with the wrong key and, after migrateInto() clears the legacy
+    // stores, permanently orphan the encrypted tokens.
+    kc.__state.readMode = 'throw';
+    await expect(setItem('k', 1)).rejects.toThrow(/keychain read failed/);
+    expect(kc.__state.mints).toBe(0); // never minted over a possibly-existing key
+    expect(await getItem('k')).toBeNull(); // read also fails safe
+
+    // The rejection must NOT be cached: once the keychain recovers, the next
+    // access retries and succeeds (a genuine first-run mint this time).
+    kc.__state.readMode = 'normal';
+    await setItem('k', 2);
+    expect(kc.__state.mints).toBe(1);
+    expect(await getItem('k')).toBe(2);
+  });
+});


### PR DESCRIPTION
Supersedes #152 with the reviewed hardening.

Moves persisted custodial (CoinOS / Strike) tokens from an MMKV store keyed by a public hardcoded string to a device-random key held in the Keychain, so the tokens cannot be decrypted from just the public APK plus the storage file.

Hardening on top of the original:
- Abort on a Keychain read error instead of minting a replacement key (a failed read is not proof the key is absent, and minting there orphans the existing store).
- Do not cache a rejected storage promise (one transient failure would otherwise wedge all storage until restart).
- Failure-path test covering both.

Original work by @s00ly (#152).
