### PR TITLE
fix(unlock): render the biometric retry button on legacy Android

### DIFF
--- a/UnlockWith.js
+++ b/UnlockWith.js
@@ -86,7 +86,11 @@ const UnlockWith = () => {
       return <ActivityIndicator />;
     } else {
       const color = colorScheme === 'dark' ? '#FFFFFF' : '#000000';
-      if ((biometricType === Biometric.TouchID || biometricType === Biometric.Biometrics) && !isStorageEncryptedEnabled) {
+      // 'Fingerprint' covers legacy Android devices, where
+      // react-native-fingerprint-scanner reports that raw string rather than
+      // 'Biometrics'. Without it the retry button never renders on those
+      // devices after a failed or cancelled prompt (relaunch-to-recover).
+      if ((biometricType === Biometric.TouchID || biometricType === Biometric.Biometrics || biometricType === 'Fingerprint') && !isStorageEncryptedEnabled) {
         return (
           <TouchableOpacity accessibilityRole="button" disabled={isAuthenticating} onPress={unlockWithBiometrics}>
             <Icon name="fingerprint" size={64} type="font-awesome5" color={color} />


### PR DESCRIPTION
Follow-up to #147 (merged).

renderUnlockOptions only matched Touch ID / Face ID / Biometrics. On legacy Android, react-native-fingerprint-scanner reports the raw string 'Fingerprint', which matched none of those, so after a failed or cancelled prompt no retry button rendered and the user had to relaunch. Include 'Fingerprint' in that branch.
