### PR TITLE
fix(privacy): allow seed-backup screenshots, keep the shield elsewhere

### DIFF
--- a/blue_modules/Privacy.android.tsx
+++ b/blue_modules/Privacy.android.tsx
@@ -7,6 +7,10 @@ import { isPrivacyBlurOn, setPrivacyBlurMasterSwitch } from './privacySetting';
 interface PrivacyComponent extends React.FC {
   enableBlur: () => void;
   disableBlur: () => void;
+  // Lighter variant for seed-backup screens: keeps the app-switcher blur but
+  // does not block screenshots, so users can screenshot their seed to back it up.
+  enableBlurAllowingScreenshots: () => void;
+  disableBlurAllowingScreenshots: () => void;
 }
 
 const Privacy: PrivacyComponent = () => {
@@ -33,5 +37,16 @@ Privacy.enableBlur = () => {
 Privacy.disableBlur = () => {
   Obscure.deactivateObscure();
 };
+
+// Seed-backup screens: the user should be able to screenshot their seed to
+// back it up. Android's only blur mechanism is FLAG_SECURE (Obscure), which
+// ALSO blocks screenshots, so there is no way to hide the app-switcher preview
+// without blocking the backup screenshot. Ensure it is off here (a prior screen
+// may have set it) and do not re-enable it.
+Privacy.enableBlurAllowingScreenshots = () => {
+  Obscure.deactivateObscure();
+};
+
+Privacy.disableBlurAllowingScreenshots = () => {};
 
 export default Privacy;

--- a/blue_modules/Privacy.ios.tsx
+++ b/blue_modules/Privacy.ios.tsx
@@ -7,6 +7,10 @@ import { isPrivacyBlurOn, setPrivacyBlurMasterSwitch } from './privacySetting';
 interface PrivacyComponent extends React.FC {
   enableBlur: () => void;
   disableBlur: () => void;
+  // Lighter variant for seed-backup screens: keeps the app-switcher blur but
+  // does not block screenshots, so users can screenshot their seed to back it up.
+  enableBlurAllowingScreenshots: () => void;
+  disableBlurAllowingScreenshots: () => void;
 }
 
 const Privacy: PrivacyComponent = () => {
@@ -32,6 +36,17 @@ Privacy.enableBlur = () => {
 
 Privacy.disableBlur = () => {
   enabled(false);
+};
+
+// On iOS enableBlur only blurs the app-switcher snapshot; it never blocked
+// screenshots (iOS exposes no such API). So the screenshot-allowing variant is
+// identical to enableBlur, keeping the app-switcher blur on seed-backup screens.
+Privacy.enableBlurAllowingScreenshots = () => {
+  Privacy.enableBlur();
+};
+
+Privacy.disableBlurAllowingScreenshots = () => {
+  Privacy.disableBlur();
 };
 
 export default Privacy;

--- a/blue_modules/Privacy.tsx
+++ b/blue_modules/Privacy.tsx
@@ -3,6 +3,8 @@ import React from 'react';
 interface PrivacyComponent extends React.FC {
   enableBlur: () => void;
   disableBlur: () => void;
+  enableBlurAllowingScreenshots: () => void;
+  disableBlurAllowingScreenshots: () => void;
 }
 
 const Privacy: PrivacyComponent = () => {
@@ -16,6 +18,14 @@ Privacy.enableBlur = () => {
 
 Privacy.disableBlur = () => {
   // Define the disableBlur behavior
+};
+
+Privacy.enableBlurAllowingScreenshots = () => {
+  // no-op on unsupported platforms
+};
+
+Privacy.disableBlurAllowingScreenshots = () => {
+  // no-op on unsupported platforms
 };
 
 export default Privacy;

--- a/screen/wallets/export.js
+++ b/screen/wallets/export.js
@@ -52,7 +52,7 @@ const WalletExport = () => {
 
   useFocusEffect(
     useCallback(() => {
-      Privacy.enableBlur();
+      Privacy.enableBlurAllowingScreenshots();
       const task = InteractionManager.runAfterInteractions(async () => {
         if (wallet) {
           const isBiometricsEnabled = await Biometric.isBiometricUseCapableAndEnabled();
@@ -71,7 +71,7 @@ const WalletExport = () => {
       });
       return () => {
         task.cancel();
-        Privacy.disableBlur();
+        Privacy.disableBlurAllowingScreenshots();
       };
     }, [goBack, saveToDisk, wallet]),
   );

--- a/screen/wallets/pleaseBackup.tsx
+++ b/screen/wallets/pleaseBackup.tsx
@@ -41,11 +41,11 @@ const PleaseBackup: React.FC = () => {
   }, [navigation]);
 
   useEffect(() => {
-    Privacy.enableBlur();
+    Privacy.enableBlurAllowingScreenshots();
     setIsLoading(false);
     const subscription = BackHandler.addEventListener('hardwareBackPress', handleBackButton);
     return () => {
-      Privacy.disableBlur();
+      Privacy.disableBlurAllowingScreenshots();
       subscription.remove();
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/screen/wallets/pleaseBackupLNDHub.js
+++ b/screen/wallets/pleaseBackupLNDHub.js
@@ -38,10 +38,10 @@ const PleaseBackupLNDHub = () => {
   });
 
   useEffect(() => {
-    Privacy.enableBlur();
+    Privacy.enableBlurAllowingScreenshots();
     const subscription = BackHandler.addEventListener('hardwareBackPress', handleBackButton);
     return () => {
-      Privacy.disableBlur();
+      Privacy.disableBlurAllowingScreenshots();
       subscription.remove();
     };
   }, [handleBackButton]);

--- a/screen/wallets/pleaseBackupLdk.js
+++ b/screen/wallets/pleaseBackupLdk.js
@@ -42,10 +42,10 @@ const PleaseBackupLdk = () => {
   });
 
   useEffect(() => {
-    Privacy.enableBlur();
+    Privacy.enableBlurAllowingScreenshots();
     const subscription = BackHandler.addEventListener('hardwareBackPress', handleBackButton);
     return () => {
-      Privacy.disableBlur();
+      Privacy.disableBlurAllowingScreenshots();
       subscription.remove();
     };
   }, [handleBackButton]);


### PR DESCRIPTION
Follow-up to #148 (merged). Implements the agreed option 2.

The four seed-backup screens (export, please-backup, LDK, LNDHub) now use a screenshot-allowing variant of the privacy shield so users can screenshot their seed to back it up. On iOS this keeps the app-switcher blur (iOS never blocked screenshots anyway); on Android it skips FLAG_SECURE, the only mechanism there, which would otherwise block the backup screenshot. xpub, addresses, seed-entry (import), and send keep the full shield.
