### PR TITLE
ark: recovery requires seed + .cbark backup, not seed alone

### DIFF
--- a/src/screens/Account/CreateArkScreen/index.tsx
+++ b/src/screens/Account/CreateArkScreen/index.tsx
@@ -320,11 +320,13 @@ export default function CreateArkScreen() {
                     <Text style={styles.warnTitle}>⚠ Experimental</Text>
                     <Text style={styles.warnBody}>
                         Ark is a new Bitcoin Layer 2 protocol (by Second.tech). It enables
-                        cheap non-custodial Lightning-style payments — but the SDK is pre-1.0
-                        and wallet recovery from seed is <Text bold>not yet supported</Text>.
+                        cheap non-custodial Lightning-style payments. The SDK is still
+                        pre-1.0, so treat it as experimental.
                     </Text>
                     <Text style={styles.warnBody}>
-                        Use for small amounts only until recovery ships.
+                        Recovery needs <Text bold>both</Text> your seed phrase and your
+                        backup file (.cbark). Your seed alone is not enough, so always
+                        keep a current backup.
                     </Text>
 
                     <View style={styles.divider} />

--- a/src/services/ark/config.ts
+++ b/src/services/ark/config.ts
@@ -10,11 +10,11 @@ import { Config, Network } from '@secondts/bark-react-native';
  * visible in archive/TestFlight builds for ongoing testing and for
  * eventual production rollout.
  *
- * Note: the original comment flagged that seed-alone recovery cannot
- * restore Ark balance per Bark's docs (encrypted backup/restore is the
- * Phase 2 work). That's still a real footgun for end users — make sure
- * the in-app UX surfaces the "back up your seed AND your VTXO state"
- * warning before going live to non-tester users.
+ * Note: seed-alone recovery cannot restore Ark VTXO balance (the ASP has
+ * no lookup-by-pubkey endpoint, so VTXO state can only come from the
+ * encrypted .cbark backup). That backup/restore has shipped: recovery is
+ * seed + .cbark. Keep the in-app UX surfacing the "back up your seed AND
+ * your VTXO state" warning, since seed-only still lands an empty balance.
  */
 export const FEATURE_ARK_ENABLED = true;
 

--- a/src/services/ark/recover.ts
+++ b/src/services/ark/recover.ts
@@ -218,12 +218,13 @@ export async function recoverArkWalletFromKeychain(): Promise<ArkRecoveryResult>
     }
 
     try {
-        // forceRescan=true → SDK queries the ASP for VTXOs owned by this
-        // seed's pubkey and rehydrates the empty datadir with them.
-        // This is what makes seed-only recovery actually return funds
-        // instead of an empty wallet.
+        // forceRescan=true rescans the on-chain BDK side for this seed, but
+        // it does NOT restore Ark VTXOs: the ASP has no lookup-by-pubkey
+        // endpoint, so VTXO state can only come from the .cbark backup.
+        // Seed-only recovery therefore lands a wallet with no VTXO balance;
+        // this path is a last resort for users who have no backup file.
         await createArkWallet(mnemonic, true);
-        console.log('[Ark recover] wallet recreated successfully (with ASP rescan)');
+        console.log('[Ark recover] wallet recreated (on-chain rescan only, no VTXO restore)');
     } catch (err: any) {
         console.log('[Ark recover] createArkWallet failed:', err?.message ?? err, err);
         return { ok: false, reason: 'wallet-create-failed', cause: err };


### PR DESCRIPTION
Corrects the Ark recovery copy and flow so it is clear that recovery needs both the seed and the .cbark backup file, not the seed alone.

## Changes
- Update the CreateArkScreen recovery copy.
- Align src/services/ark/config.ts and src/services/ark/recover.ts wording with the seed-plus-backup requirement.

## Notes
- JS-only: no dependency, native, or lockfile changes.
