### PR TITLE
chore(release): bump Android versionCode to 32

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -99,7 +99,7 @@ android {
         applicationId "io.cypherbox.btc"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 31
+        versionCode 32
         versionName "0.1.5"
         testBuildType System.getProperty('testBuildType', 'debug')
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'


### PR DESCRIPTION
Bumps Android `versionCode` 31 to 32. versionCode 31 was already uploaded to Play, and Play requires a strictly higher code for the next upload. `versionName` stays 0.1.5 and the iOS build number is unaffected. The android-release build must be re-run from main after this merges to produce the AAB with versionCode 32; the previous AAB (vc31) cannot be uploaded.