### PR TITLE
feat(ark): delegated refresh + fund-safety hardening (v0.1.6 / vc33)

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -99,8 +99,8 @@ android {
         applicationId "io.cypherbox.btc"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 32
-        versionName "0.1.5"
+        versionCode 33
+        versionName "0.1.6"
         testBuildType System.getProperty('testBuildType', 'debug')
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
         missingDimensionStrategy 'react-native-camera', 'general' //add this line

--- a/ios/BlueWallet.xcodeproj/project.pbxproj
+++ b/ios/BlueWallet.xcodeproj/project.pbxproj
@@ -1196,7 +1196,7 @@
 					"$(SDKROOT)/System/iOSSupport/usr/lib/swift",
 					"$(inherited)",
 				);
-				MARKETING_VERSION = 0.1.5;
+				MARKETING_VERSION = 0.1.6;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",
@@ -1246,7 +1246,7 @@
 					"$(SDKROOT)/System/iOSSupport/usr/lib/swift",
 					"$(inherited)",
 				);
-				MARKETING_VERSION = 0.1.5;
+				MARKETING_VERSION = 0.1.6;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cypherbox",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cypherbox",
-      "version": "0.1.5",
+      "version": "0.1.6",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cypherbox",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/src/custom-hooks/useArkoorReceivePrompt.ts
+++ b/src/custom-hooks/useArkoorReceivePrompt.ts
@@ -7,7 +7,7 @@ import {
     ARK_ARKOOR_ASSUMED_DAYS,
     ArkRefreshInFlightError,
     cancelVtxoExpiryWarnings,
-    refreshArkVtxosAndSync,
+    refreshArkVtxosDelegatedAndSync,
     scheduleVtxoExpiryWarnings,
 } from '@Cypher/services/ark';
 import { SPEND_GRACE_MS } from '@Cypher/services/ark/refreshDeferral';
@@ -53,10 +53,11 @@ import { recordEvent } from '@Cypher/stores/eventLogStore';
  *   the popup fires on next foreground because the state is persisted.
  *   The 24h push (scheduled at first observation, not at dismissal) is the
  *   safety net for users who never return.
- * - "Refresh now" calls refreshArkVtxosAndSync which is long-running
- *   (round cadence is ~1h on mainnet). We DO NOT block the UI on it — fire
- *   and forget. The existing per-row spinning refresh icon on the Capsules
- *   tab surfaces in-flight state if the user navigates there.
+ * - "Refresh now" calls refreshArkVtxosDelegatedAndSync, which returns as
+ *   soon as the ASP accepts the delegation (seconds); the round then
+ *   completes in the background. We fire and forget either way. The existing
+ *   per-row spinning refresh icon on the Capsules tab surfaces in-flight
+ *   state if the user navigates there.
  */
 export default function useArkoorReceivePrompt(): void {
     const arkVtxos = useAuthStore((s) => s.arkVtxos);
@@ -260,7 +261,7 @@ export default function useArkoorReceivePrompt(): void {
         const body =
             `You just received ${amountPhrase} to your Bark Vault.\n\n` +
             `These sats expire in about ${ARK_ARKOOR_ASSUMED_DAYS} days unless they're refreshed into a long-life capsule. ` +
-            `Refreshing takes up to an hour, during which the sats can't be spent.` +
+            `Refreshing locks these sats for up to an hour while it finishes in the background, and you don't need to keep the app open.` +
             autoRefreshNote;
         const dontRefreshLabel =
             sats != null
@@ -325,7 +326,7 @@ export default function useArkoorReceivePrompt(): void {
                     },
                 },
                 {
-                    text: 'Refresh now (~1 hour, recommended)',
+                    text: 'Refresh now (recommended)',
                     onPress: () => {
                         try {
                             recordEvent({
@@ -358,14 +359,16 @@ export default function useArkoorReceivePrompt(): void {
                                     err,
                                 );
                             }
-                            // Fire-and-forget. refreshArkVtxosAndSync resolves
-                            // when the round completes (~1h on mainnet). The
-                            // per-row spinning icon on the Capsules tab is the
-                            // user-visible in-flight signal — we don't block
-                            // here so the popup dismissal feels immediate.
-                            refreshArkVtxosAndSync([firstId], sats ?? undefined).catch((err) => {
+                            // Fire-and-forget. refreshArkVtxosDelegatedAndSync
+                            // resolves as soon as the ASP accepts the delegation
+                            // (seconds); the round then completes in the
+                            // background. The per-row spinning icon on the
+                            // Capsules tab is the user-visible in-flight signal,
+                            // and we don't block here so the dismissal feels
+                            // immediate.
+                            refreshArkVtxosDelegatedAndSync([firstId], sats ?? undefined).catch((err) => {
                                 console.warn(
-                                    '[useArkoorReceivePrompt] refreshArkVtxosAndSync threw:',
+                                    '[useArkoorReceivePrompt] refreshArkVtxosDelegatedAndSync threw:',
                                     err?.message ?? err,
                                 );
                                 // Don't roll status back to 'pending' — that would

--- a/src/custom-hooks/useArkoorReceivePrompt.ts
+++ b/src/custom-hooks/useArkoorReceivePrompt.ts
@@ -371,46 +371,45 @@ export default function useArkoorReceivePrompt(): void {
                                     '[useArkoorReceivePrompt] refreshArkVtxosDelegatedAndSync threw:',
                                     err?.message ?? err,
                                 );
-                                // Don't roll status back to 'pending' — that would
-                                // re-prompt the user on the next render, which is
-                                // worse than silent failure. The existing per-row
-                                // refresh affordance lets them retry manually.
-                                //
-                                // EXCEPT for the round-in-flight rejection: nothing
-                                // was submitted, and we already cancelled this
-                                // capsule's expiry warnings above in anticipation of
-                                // the refresh. Restore the warnings and mark the
-                                // entry dismissed (spendable, protected, no
-                                // re-prompt) so the capsule isn't left with no
-                                // safety net.
-                                if (err instanceof ArkRefreshInFlightError) {
-                                    const cur = useAuthStore.getState().arkArkoorPromptState;
-                                    const existing2 = cur[firstId];
-                                    if (existing2) {
-                                        setArkArkoorPromptState({
-                                            ...cur,
-                                            [firstId]: {
-                                                ...existing2,
-                                                status: 'dismissed',
-                                                dismissedAt: Date.now(),
-                                            },
-                                        });
-                                    }
-                                    const exp2 = (existing2?.observedAt ?? Date.now()) +
-                                        ARK_ARKOOR_ASSUMED_DAYS * 24 * 60 * 60 * 1000;
-                                    try {
-                                        scheduleVtxoExpiryWarnings(firstId, exp2, sats ?? undefined);
-                                    } catch (schedErr) {
-                                        console.warn(
-                                            '[useArkoorReceivePrompt] re-schedule after in-flight reject threw:',
-                                            schedErr,
-                                        );
-                                    }
-                                    SimpleToast.show(
-                                        'A refresh is already running. These sats stay spendable, refresh them from Capsules once it finishes.',
-                                        SimpleToast.LONG,
+                                // The optimistic 'refreshed' status + expiry-warning
+                                // cancel above ran BEFORE this submit (so the prompt
+                                // would not re-fire mid-flight). On ANY failure that
+                                // optimism is wrong: nothing is refreshing, and leaving
+                                // the warnings cancelled lets the arkoor's expiry fuse
+                                // run down with zero signal. So for every failure,
+                                // restore the safety net: mark the entry 'dismissed'
+                                // (spendable, protected, no re-prompt spam) and re-arm
+                                // the expiry warnings. Only the toast copy differs by
+                                // cause; the per-row Capsules refresh stays as the
+                                // manual retry.
+                                const cur = useAuthStore.getState().arkArkoorPromptState;
+                                const existing2 = cur[firstId];
+                                if (existing2) {
+                                    setArkArkoorPromptState({
+                                        ...cur,
+                                        [firstId]: {
+                                            ...existing2,
+                                            status: 'dismissed',
+                                            dismissedAt: Date.now(),
+                                        },
+                                    });
+                                }
+                                const exp2 = (existing2?.observedAt ?? Date.now()) +
+                                    ARK_ARKOOR_ASSUMED_DAYS * 24 * 60 * 60 * 1000;
+                                try {
+                                    scheduleVtxoExpiryWarnings(firstId, exp2, sats ?? undefined);
+                                } catch (schedErr) {
+                                    console.warn(
+                                        '[useArkoorReceivePrompt] re-schedule after refresh failure threw:',
+                                        schedErr,
                                     );
                                 }
+                                SimpleToast.show(
+                                    err instanceof ArkRefreshInFlightError
+                                        ? 'A refresh is already running. These sats stay spendable, refresh them from Capsules once it finishes.'
+                                        : 'Refresh did not go through. Your sats are still spendable and protected. Try again from Capsules.',
+                                    SimpleToast.LONG,
+                                );
                             });
                         } finally {
                             promptInFlight.current = false;

--- a/src/screens/Strike/CheckingAccountNew/ArkCapsules.tsx
+++ b/src/screens/Strike/CheckingAccountNew/ArkCapsules.tsx
@@ -1467,6 +1467,44 @@ export default function ArkCapsules({ matchedRate, currency }: ArkCapsulesProps)
 
         setRefreshing(true);
         try {
+            // G5: the store's vtxo list lags the ASP right after an arkoor
+            // send, so `ids` (built from the last poll) can still include a
+            // VTXO already spent server-side. Submitting a spent input makes
+            // the ASP reject the whole round (and inflates the fail streak).
+            // Resync and drop any id that is no longer a live, non-locked
+            // capsule before we estimate/submit. Same resync the stuck-round
+            // retry uses; a spent VTXO falls out of the store's spendable list,
+            // so "still present and not locked" is the liveness test.
+            try {
+                await syncArkWallet();
+                await Promise.all([fetchArkBalance(), fetchArkVtxos()]);
+            } catch (syncErr: any) {
+                console.warn(
+                    '[Ark refresh] pre-submit resync failed, proceeding with last-known set:',
+                    syncErr?.message ?? syncErr,
+                );
+            }
+            const liveIds = new Set(
+                (useAuthStore.getState().arkVtxos ?? [])
+                    .filter((v) => v.state.toLowerCase() !== 'locked')
+                    .map((v) => v.id),
+            );
+            const droppedStale = ids.filter((id) => !liveIds.has(id));
+            if (droppedStale.length > 0) {
+                ids = ids.filter((id) => liveIds.has(id));
+                console.log(
+                    '[Ark refresh] dropped', droppedStale.length,
+                    'stale/spent vtxo(s) after resync; refreshing', ids.length,
+                );
+            }
+            if (ids.length === 0) {
+                SimpleToast.show(
+                    'Those capsules just changed state (spent or now in a round), so there is nothing left to refresh.',
+                    SimpleToast.LONG,
+                );
+                setRefreshing(false);
+                return;
+            }
             const fee = await estimateArkRefreshFee(ids);
             // Present fee preview + confirmation before committing. The
             // delegation costs a round fee, so the user should opt in

--- a/src/screens/Strike/CheckingAccountNew/ArkCapsules.tsx
+++ b/src/screens/Strike/CheckingAccountNew/ArkCapsules.tsx
@@ -24,7 +24,7 @@ import {
     getArkCancelling,
     getArkWalletHandle,
     ArkRefreshInFlightError,
-    refreshArkVtxosAndSync,
+    refreshArkVtxosDelegatedAndSync,
     restoreArkWalletFromDisk,
     setArkCancelling,
     syncArkWallet,
@@ -1459,8 +1459,8 @@ export default function ArkCapsules({ matchedRate, currency }: ArkCapsulesProps)
             );
             ids = refreshable;
         }
-        // Post-filter input total (drives the refreshArkVtxosAndSync amount
-        // arg + telemetry below).
+        // Post-filter input total (drives the refreshArkVtxosDelegatedAndSync
+        // amount arg + telemetry below).
         const totalIn = rows
             .filter((r) => ids.includes(r.id))
             .reduce((acc, r) => acc + r.sats, 0);
@@ -1468,9 +1468,9 @@ export default function ArkCapsules({ matchedRate, currency }: ArkCapsulesProps)
         setRefreshing(true);
         try {
             const fee = await estimateArkRefreshFee(ids);
-            // Present fee preview + confirmation before committing. Round is
-            // blocking and can take seconds-to-minutes, so the user should
-            // opt in explicitly rather than have it happen silently. The
+            // Present fee preview + confirmation before committing. The
+            // delegation costs a round fee, so the user should opt in
+            // explicitly rather than have it happen silently. The
             // notification-tap path skips this dialog: the user already
             // signalled intent by tapping the warning and the deep-link
             // would be pointless if we then asked them to tap Refresh
@@ -1481,7 +1481,8 @@ export default function ArkCapsules({ matchedRate, currency }: ArkCapsulesProps)
                     Alert.alert(
                         "Refresh capsules?",
                         `Re-board ${ids.length} capsule(s) into a new Ark round for ~${fee.feeSats} sats. ` +
-                        `This extends their expiry by another full lifetime and may take up to a minute.`,
+                        `This extends their expiry by another full lifetime. It finishes in the background ` +
+                        `within the hour, so you can close the app once it's submitted.`,
                         [
                             { text: "Cancel", style: "cancel", onPress: () => resolve(false) },
                             { text: "Refresh", onPress: () => resolve(true) },
@@ -1494,58 +1495,25 @@ export default function ArkCapsules({ matchedRate, currency }: ArkCapsulesProps)
                 return;
             }
 
-            // Watchdog: we don't want the spinner to be held hostage if the
-            // ASP round drags on or the SDK never surfaces completion (we've
-            // observed rounds sitting in the Locked state for many minutes
-            // while the server thinks about it). The underlying SDK call
-            // can't be cancelled — Bark doesn't expose an AbortSignal —
-            // but we DO want the UI to release. After the timeout we stop
-            // waiting on the refresh promise and trust the 30s `useArkSync`
-            // loop to catch completion: when `pendingInRoundSats` drops to
-            // 0 and the Locked VTXO turns Spendable, the capsules view
-            // rerenders on its own. We attach a passive `.catch` so an
-            // eventual rejection from the detached promise doesn't become
-            // an unhandled rejection.
-            // Bump the queued-rounds counter as we hand off to the SDK.
-            // The counter resets to 0 in the pendingRoundSats === 0 effect
-            // above when the round either commits or times out server-side.
+            // Delegated refresh: hand the capsules to the ASP to re-board in
+            // the next round. Returns as soon as the server ACCEPTS them
+            // (seconds), not when the round finishes. The round then completes
+            // server-side with no app presence needed, so the user can close
+            // the app. The capsules carry the "Refreshing" row treatment
+            // (Locked in round) until a later sync ingests the refreshed VTXO.
+            // Bump the queued-rounds counter so the in-flight UI reflects the
+            // pending round; it resets in the pendingRoundSats === 0 effect
+            // above when the round commits server-side.
             queuedRoundsCountRef.current += 1;
             setQueuedRoundsCount(queuedRoundsCountRef.current);
 
-            const WATCHDOG_MS = 90_000;
-            type RefreshResult = Awaited<ReturnType<typeof refreshArkVtxosAndSync>>;
-            const refreshPromise: Promise<RefreshResult> = refreshArkVtxosAndSync(ids, totalIn);
-            // Detach the rejection handler so the promise won't complain
-            // if it settles after the watchdog fires.
-            refreshPromise.catch((detachedErr) => {
-                console.warn('[Ark refresh] detached promise eventually rejected:', detachedErr);
-            });
-            const timeoutSentinel = Symbol('refresh-watchdog');
-            const raced = await Promise.race<RefreshResult | typeof timeoutSentinel>([
-                refreshPromise,
-                new Promise((resolve) =>
-                    setTimeout(() => resolve(timeoutSentinel), WATCHDOG_MS),
-                ),
-            ]);
-            if (raced === timeoutSentinel) {
-                // Fall back to "it's in flight" UX. Clear the selection so
-                // the user can't accidentally re-trigger the same IDs —
-                // they're now marked pendingRound in the row data anyway.
-                setSelectedIds([]);
-                SimpleToast.show(
-                    `Refresh still in progress — this can take a minute on busy rounds. ` +
-                    `Your capsule will appear here when it finalises.`,
-                    SimpleToast.LONG,
-                );
-            } else {
-                setSelectedIds([]);
-                SimpleToast.show(
-                    raced.roundId
-                        ? `Refreshed ${ids.length} capsule(s) in round ${raced.roundId.slice(0, 8)}…`
-                        : `Refresh completed for ${ids.length} capsule(s)`,
-                    SimpleToast.LONG,
-                );
-            }
+            await refreshArkVtxosDelegatedAndSync(ids, totalIn);
+            setSelectedIds([]);
+            SimpleToast.show(
+                `Refresh submitted for ${ids.length} capsule${ids.length === 1 ? '' : 's'}. ` +
+                `They finish in the background within the hour, so you can close the app.`,
+                SimpleToast.LONG,
+            );
         } catch (err: any) {
             // Round already in flight: nothing was submitted, this isn't a
             // failure. Tell the user to let the running round finish.

--- a/src/screens/Strike/CheckingAccountNew/Settings.tsx
+++ b/src/screens/Strike/CheckingAccountNew/Settings.tsx
@@ -52,6 +52,7 @@ import {
   resetArkWalletState,
   setArkBackgroundRefreshEnabled,
   startArkEmergencyExit,
+  writeAndVerifyArkBackup,
   writeArkBackupToTempFile,
 } from "@Cypher/services/ark";
 import type { ExitFeeConvertEstimate } from "@Cypher/services/ark";
@@ -1328,14 +1329,53 @@ export function ArkSettingsBody({ view = 'backup' }: { view?: 'backup' | 'action
     setDeleteModalVisible(false);
     setDeleting(true);
     try {
+      // Fund-safety gate: Ark VTXO state is NOT seed-derivable, so wiping the
+      // datadir without a current, verified backup is silent, permanent fund
+      // loss. Force a fresh verified backup BEFORE the wipe and refuse to
+      // delete if we can't produce one. reset() does not pass
+      // deleteBackupFilesForFingerprint, so this .cbark survives the wipe and
+      // stays a valid restore source afterward. Mirrors the wallet-create
+      // policy that a user can't proceed without a verified backup.
+      const mnemonic = await readArkSeedPhrase();
+      if (!mnemonic) {
+        SimpleToast.show(
+          "Couldn't read your seed to back up first, so delete was cancelled. Your funds are untouched.",
+          SimpleToast.LONG,
+        );
+        setDeleting(false);
+        return;
+      }
+      try {
+        const verified = await writeAndVerifyArkBackup(mnemonic);
+        if (!verified.local.ok) {
+          SimpleToast.show(
+            `Couldn't write a verified backup (${verified.local.error}), so delete was cancelled. Your funds are untouched.`,
+            SimpleToast.LONG,
+          );
+          setDeleting(false);
+          return;
+        }
+      } catch (backupErr: any) {
+        // writeAndVerifyArkBackup throws only on a fundamental pack failure
+        // (e.g. empty or locked datadir). Treat as "cannot guarantee a
+        // backup" and abort the delete rather than risk silent loss.
+        console.warn('[Ark] pre-delete backup failed:', backupErr);
+        SimpleToast.show(
+          `Couldn't create a backup to protect your funds, so delete was cancelled: ${backupErr?.message ?? "unknown error"}`,
+          SimpleToast.LONG,
+        );
+        setDeleting(false);
+        return;
+      }
+
       await resetArkWalletState({ keepSeedInKeychain: keepSeedOnDevice });
       if (typeof clearArkAuth === 'function') {
         clearArkAuth();
       }
       SimpleToast.show(
         keepSeedOnDevice
-          ? "Ark vault deleted. Seed kept on device for biometric recovery."
-          : "Ark vault deleted from this device.",
+          ? "Backup verified. Ark vault deleted. Seed kept on device for biometric recovery."
+          : "Backup verified. Ark vault deleted from this device.",
         SimpleToast.LONG,
       );
       setTimeout(() => navigation.goBack(), 300);

--- a/src/services/ark/index.ts
+++ b/src/services/ark/index.ts
@@ -132,9 +132,12 @@ export {
     fetchArkPendingRoundStates,
     fetchArkRoundIntervalSecs,
     fetchArkMinBoardSats,
+    maintenanceArkDelegated,
     progressArkPendingRounds,
     refreshArkVtxos,
     refreshArkVtxosAndSync,
+    refreshArkVtxosDelegated,
+    refreshArkVtxosDelegatedAndSync,
 } from './refresh';
 
 export {
@@ -163,7 +166,7 @@ export {
     probeAspReachable,
 } from './exitFunding';
 export type { ExitFeeReserve, ExitFeeConvertEstimate } from './exitFunding';
-export type { ArkRefreshFeeView, ArkRefreshResult } from './refresh';
+export type { ArkRefreshFeeView, ArkRefreshResult, ArkDelegatedRefreshResult } from './refresh';
 
 export { setArkBackgroundRefreshEnabled } from './backgroundRefresh';
 

--- a/src/services/ark/refresh.ts
+++ b/src/services/ark/refresh.ts
@@ -190,6 +190,165 @@ export async function refreshArkVtxosAndSync(
     return result;
 }
 
+export type ArkDelegatedRefreshResult = {
+    /**
+     * RoundState the ASP returned when it ACCEPTED the delegation, or null if
+     * the SDK scheduled nothing. Note this is "accepted", not "completed": the
+     * server finishes the round later and the refreshed VTXO only appears after
+     * a subsequent `sync()`.
+     */
+    roundState: RoundState | null;
+};
+
+/**
+ * Delegated refresh — the mobile-appropriate path. Hands the given VTXOs to
+ * the ASP to re-board on our behalf in the next round.
+ *
+ * Unlike self-signed `refreshArkVtxos` (which blocks for the whole round, up
+ * to ~1h, and needs the app foregrounded the entire time), this returns as
+ * soon as the ASP ACCEPTS the delegation (seconds). The server then carries
+ * the round to completion with no client presence, so the app can background
+ * immediately. Confirmed reliable by Second.tech.
+ *
+ * IMPORTANT: resolving here means "delegation accepted", NOT "VTXO refreshed".
+ * The refreshed VTXO materialises only after the round finalises server-side
+ * and a later `sync()` ingests it. That later sync is also where the client
+ * VALIDATES the new VTXO (the liveness/verification step the trust model
+ * requires).
+ *
+ * Serialization: we reuse the same ongoing-round pre-check as the self-signed
+ * path (one wallet cannot be in two rounds at once). We do NOT hold the
+ * `refreshSubmissionInFlight` flag for the round's duration the way the
+ * blocking path does, because this call returns long before the round ends;
+ * the `pendingRoundStates` ongoing-check is what prevents overlap across the
+ * server-side round.
+ */
+export async function refreshArkVtxosDelegated(
+    vtxoIds: string[],
+    totalSats?: number,
+): Promise<ArkDelegatedRefreshResult> {
+    const handle = requireHandle();
+
+    // Block only when a round is genuinely still ongoing server-side. A
+    // finalising (`ongoing=false`) round has terminated and the next sync
+    // ingests it, so it must not block a fresh delegation.
+    const pending = await fetchArkPendingRoundStates();
+    const ongoingCount = pending.filter((r) => r.ongoing).length;
+    if (ongoingCount > 0) {
+        console.log(
+            '[Ark refresh] delegated submission blocked:', ongoingCount,
+            'round(s) already ongoing',
+        );
+        throw new ArkRefreshInFlightError(ongoingCount);
+    }
+
+    console.log(
+        '[Ark refresh] refreshVtxosDelegated() calling for', vtxoIds.length,
+        'vtxo(s):', vtxoIds.map((id) => id.slice(0, 12) + '…'),
+    );
+    const t0 = Date.now();
+    const correlationId = `${t0.toString(36)}-${Math.random().toString(36).slice(2, 7)}`;
+    recordEvent({
+        kind: 'ark-refresh-started',
+        vtxoCount: vtxoIds.length,
+        totalSats: totalSats ?? 0,
+        correlationId,
+    });
+    try {
+        const roundState = await handle.refreshVtxosDelegated(vtxoIds);
+        console.log(
+            '[Ark refresh] refreshVtxosDelegated() accepted in',
+            Math.round((Date.now() - t0) / 1000), 's',
+        );
+        // "finished" here = the ASP accepted the delegation, NOT that the VTXO
+        // is refreshed. Actual completion is observed on the next sync.
+        recordEvent({
+            kind: 'ark-refresh-finished',
+            correlationId,
+            result: 'success',
+            durationMs: Date.now() - t0,
+        });
+        // Acceptance breaks the failure streak that drives the
+        // refresh-failing-near-expiry escalation in useArkSync.
+        useAuthStore.getState().setArkRefreshFailStreak(0);
+        return { roundState: roundState ?? null };
+    } catch (err: any) {
+        // BarkError carries detail in `err.inner.errorMessage`, not `err.message`.
+        const inner = err?.inner?.errorMessage ?? err?.inner?.message ?? null;
+        const tag = err?.tag ?? null;
+        console.warn(
+            '[Ark refresh] refreshVtxosDelegated() threw after',
+            Math.round((Date.now() - t0) / 1000),
+            's: tag=', tag, 'inner=', inner, 'message=', err?.message ?? String(err),
+        );
+        recordEvent({
+            kind: 'ark-refresh-finished',
+            correlationId,
+            result: 'failure',
+            durationMs: Date.now() - t0,
+        });
+        const store = useAuthStore.getState();
+        store.setArkRefreshFailStreak(store.arkRefreshFailStreak + 1);
+        throw err;
+    }
+}
+
+/**
+ * Convenience: delegated refresh + sync + refetch balance/vtxos, mirroring
+ * `refreshArkVtxosAndSync` for the self-signed path. The sync pulls the new
+ * in-round state into the local datadir so the capsule row flips to its
+ * "Refreshing" treatment without waiting for the 30s useArkSync tick. The
+ * round still completes server-side later; the refreshed VTXO appears on a
+ * subsequent sync (which is also where the client validates it).
+ */
+export async function refreshArkVtxosDelegatedAndSync(
+    vtxoIds: string[],
+    totalSats?: number,
+): Promise<ArkDelegatedRefreshResult> {
+    const handle = requireHandle();
+    const result = await refreshArkVtxosDelegated(vtxoIds, totalSats);
+    await handle.sync();
+    await Promise.all([fetchArkBalance(), fetchArkVtxos()]);
+    return result;
+}
+
+/**
+ * Background maintenance via delegation — asks the SDK to refresh whatever
+ * VTXOs are due (its own `getVtxosToRefresh` policy) and hand them to the ASP
+ * on our behalf. This is the unattended background engine: the app wakes on a
+ * silent push, calls this, then backgrounds again while the server runs the
+ * round(s).
+ *
+ * The SDK selects and submits internally (no vtxoIds arg). Like the delegated
+ * refresh above, resolving means the delegation was accepted, not that any
+ * VTXO is refreshed yet; the next `sync()` reconciles + validates.
+ *
+ * Errors are surfaced to the caller (the background trigger records telemetry
+ * and decides whether to notify), unlike `progressArkPendingRounds` which
+ * swallows.
+ */
+export async function maintenanceArkDelegated(): Promise<void> {
+    const handle = requireHandle();
+    const t0 = Date.now();
+    console.log('[Ark refresh] maintenanceDelegated() calling');
+    try {
+        await handle.maintenanceDelegated();
+        console.log(
+            '[Ark refresh] maintenanceDelegated() accepted in',
+            Math.round((Date.now() - t0) / 1000), 's',
+        );
+    } catch (err: any) {
+        const inner = err?.inner?.errorMessage ?? err?.inner?.message ?? null;
+        const tag = err?.tag ?? null;
+        console.warn(
+            '[Ark refresh] maintenanceDelegated() threw after',
+            Math.round((Date.now() - t0) / 1000),
+            's: tag=', tag, 'inner=', inner, 'message=', err?.message ?? String(err),
+        );
+        throw err;
+    }
+}
+
 /**
  * Drive any pending rounds forward.
  *

--- a/src/services/ark/refresh.ts
+++ b/src/services/ark/refresh.ts
@@ -1,6 +1,7 @@
-import { getArkWalletHandle } from './walletHandle';
+import { getArkWalletHandle, getCachedArkMnemonic } from './walletHandle';
 import { fetchArkBalance } from './balance';
 import { fetchArkVtxos } from './vtxos';
+import { writeArkAutoBackup } from './backup';
 import { recordEvent } from '@Cypher/stores/eventLogStore';
 import useAuthStore from '@Cypher/stores/authStore';
 import type { FeeEstimate, RoundState } from '@secondts/bark-react-native';
@@ -187,6 +188,16 @@ export async function refreshArkVtxosAndSync(
     // Pull the round outcome into the local datadir before we re-read.
     await handle.sync();
     await Promise.all([fetchArkBalance(), fetchArkVtxos()]);
+    // G2: eager backup so the just-refreshed state is captured now, not on
+    // the up-to-60s auto-backup tick. A reinstall in that gap would otherwise
+    // lose the new (non-seed-derivable) VTXO. Cached mnemonic (no biometric
+    // prompt), fire-and-forget with a swallowed error, mirroring the tick.
+    const eagerMnemonic = getCachedArkMnemonic();
+    if (eagerMnemonic) {
+        writeArkAutoBackup(eagerMnemonic).catch((e: any) =>
+            console.warn('[Ark refresh] eager backup failed (non-fatal):', e?.message ?? e),
+        );
+    }
     return result;
 }
 
@@ -309,6 +320,16 @@ export async function refreshArkVtxosDelegatedAndSync(
     const result = await refreshArkVtxosDelegated(vtxoIds, totalSats);
     await handle.sync();
     await Promise.all([fetchArkBalance(), fetchArkVtxos()]);
+    // G2: eager backup so the just-refreshed state is captured now, not on
+    // the up-to-60s auto-backup tick. A reinstall in that gap would otherwise
+    // lose the new (non-seed-derivable) VTXO. Cached mnemonic (no biometric
+    // prompt), fire-and-forget with a swallowed error, mirroring the tick.
+    const eagerMnemonic = getCachedArkMnemonic();
+    if (eagerMnemonic) {
+        writeArkAutoBackup(eagerMnemonic).catch((e: any) =>
+            console.warn('[Ark refresh] eager backup failed (non-fatal):', e?.message ?? e),
+        );
+    }
     return result;
 }
 


### PR DESCRIPTION
Ships Ark delegated (non-custodial) capsule refresh plus fund-safety hardening for the edge cases it touches. Version 0.1.6, Android versionCode 33 (0.1.5 / vc32 is already published, so this is a new build).

## What's in it

**Delegated refresh** (`feat(ark): switch capsule refresh to delegated path`)
The ASP runs the refresh round server-side; the client keeps unilateral exit and no longer has to stay foregrounded for the whole round. Validated live on device: the round finalised while the app was fully offline, and the refreshed VTXO was present on reopen.

**Fund-safety hardening** (`fix(ark): harden refresh and delete-vault fund-safety edge cases`)
- delete-vault forces a verified backup before wiping the datadir, and aborts if one cannot be written. Ark VTXO state is not seed-derivable, so a stale or missing backup was silent loss.
- refresh backs up eagerly after the round state lands, not only on the 30-60s tick, closing the reinstall-window loss of a just-refreshed VTXO.
- capsule refresh resyncs and drops stale or spent VTXOs before submit, so a just-spent input cannot get the whole round rejected.
- arkoor "Refresh now" restores expiry warnings and a safe status on any failure, not just the in-flight rejection, so a failed refresh cannot silently strand the capsule.

**Release** (`chore(release): bump version to 0.1.6 (Android versionCode 33)`)
0.1.6 / versionCode 33. iOS build number left to Xcode auto-manage per RELEASE.md.

## Follow-ups (tracked separately, not in this PR)
- backup staleness detection (envelope counter/hash)
- arkoor change registration (SDK-side)
- expired-in-grace refresh
- failure-escalation coverage

## Testing
- Delegated refresh happy path: validated live on device.
- Hardening fixes: verified by code review; smoke test on the Play internal track before promoting to production.
