### PR TITLE
chore(release): bump Android versionCode to 35

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -99,7 +99,7 @@ android {
         applicationId "io.cypherbox.btc"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 34
+        versionCode 35
         versionName "0.1.7"
         testBuildType System.getProperty('testBuildType', 'debug')
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'


### PR DESCRIPTION
`versionCode 34` was already used on Play, so the 0.1.7 bundle built at 34 is rejected at upload time. This bumps to 35.

- `versionName` stays `0.1.7`. Only the version code changes.
- No source or build changes, so the reproducibility proof on the current tree still holds.
- 0.1.8's targetSdk36 work had pencilled in vc35; that moves to 36.

After merge: tag `v0.1.7-vc35` on the new main HEAD, re-dispatch `android-release.yml` on the tag, then sign and upload. Commit is unsigned.